### PR TITLE
Fix issue #33

### DIFF
--- a/page-config.yaml
+++ b/page-config.yaml
@@ -331,13 +331,3 @@ pages:
       - name: Validation Warnings
       - name: Validation Errors
 
-  - title: documentation
-    path: /documentation/
-    sidemenu:
-      - name: Core GTFS
-        children:
-          - name: Best Practices
-          - name: Realtime
-      - name: GTFS Extensions
-      - name: Consolidated Specification
-      - name: Changing GTFS

--- a/scripts/fetchdata.sh
+++ b/scripts/fetchdata.sh
@@ -56,7 +56,7 @@ echo -en "---\npath: /es/reference/realtime/v1/\nlang: es\ntemplate: doc-page\n-
 # Best Practices -- !! master branch of MobilityData/gtfs-best-practices is for *staging*.
 #TODO: clone appropriate branch depending on master(staging)/production context
 git clone https://github.com/MobilityData/gtfs-best-practices.git -b master --single-branch repos/best-practices
-BEST_PRACTICES_FILES=(introduction faq publishing all-files agency stops routes trips stop_times calendar calendar_dates fare_attributes fare_rules shapes feed_info frequencies transfers loop-routes lasso-routes branches about)
+BEST_PRACTICES_FILES=(introduction all-files agency stops routes trips stop_times calendar calendar_dates fare_attributes fare_rules shapes feed_info frequencies transfers loop-routes lasso-routes branches about)
 
 mkdir -p src/pages/en/best-practices
 PAGE=src/pages/en/best-practices/index.md

--- a/src/pages/en/documentation/index.md
+++ b/src/pages/en/documentation/index.md
@@ -1,0 +1,18 @@
+---
+path: /documentation/
+lang: en
+---
+# General Documentation
+
+This section provides general information about GTFS datasets:
+- [Format and structure of the files that comprise a GTFS dataset] (/reference/static/) </li>
+
+- [Recommendations for describing public transportation services] (/best-practices/)
+
+- [Information about GTFS Realtime] (/reference/realtime/v2/)
+
+- [Extensions : information about specialized functionality to the core specification] (/extensions/)
+
+- [Consolidated Specification: link and content to be added later]
+
+- [GTFS: a data format that can change thanks to the community] (/changes/)


### PR DESCRIPTION
Deletes import of faq and recommendations for 

publishing pages from best-practices

**Summary:**

This PR adds the documentation.md file to gtfs.org
documentation.md prints links that redirect to /reference/static/, best-practices, realtime, and changes

This PR also deletes FAQ and all-pages imports from best-practices in the script.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] ~~Run the unit tests with `npm test` to make sure you didn't break anything~~
- [x] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)

<img width="449" alt="Capture d’écran, le 2019-12-20 à 18 52 07" src="https://user-images.githubusercontent.com/35747326/71299164-fa805f80-2359-11ea-8da9-b4a82e97ff40.png">
