### PR TITLE
Streamlined content on About page

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -1,19 +1,27 @@
+<a class="pencil-link" href="https://github.com/MobilityData/gtfs.org/edit/main/docs/about.md" title="Edit this page" target="_blank">
+    <svg class="pencil" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M10 20H6V4h7v5h5v3.1l2-2V8l-6-6H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h4v-2m10.2-7c.1 0 .3.1.4.2l1.3 1.3c.2.2.2.6 0 .8l-1 1-2.1-2.1 1-1c.1-.1.2-.2.4-.2m0 3.9L14.1 23H12v-2.1l6.1-6.1 2.1 2.1Z"></path></svg>
+  </a>
+
+<style>
+  .md-nav .md-nav--secondary {
+      display: none !important;
+    }
+</style>
+  
 # About
 
-gtfs.org is a central platform presenting documentation on GTFS. The content on this site is maintained by [MobilityData](https://mobilitydata.org/).
+GTFS.org is the central documentation platform for the General Transit Feed Specification. This site and its contents are maintained by [MobilityData](https://mobilitydata.org/) and the GTFS community. 
 
-Thank you to [Andrew Byrd](https://www.linkedin.com/in/byrdandrew) for the leadership in establishing gtfs.org and the ongoing use of this domain name.
+GTFS.org hosts open license content pulled from various Github repositories. To propose edits to content, navigate to the respective page on GTFS.org and click on the "Edit this page" icon on the top-right of the page. The "Edit this page" icon will direct the user to propose edits  on the respective Github repository as a pull request. 📝
 
-## Editing this site
+To propose a feature, content addition, or UI/UX improvement, open an [issue](https://github.com/MobilityData/gtfs.org/issues/new) on the GTFS.org repository.
 
-The GTFS Documentation Platform is based on open source content pulled from various repositories. To propose edits to content, open an issue or pull request in the respective source-of-truth repository found in the [README](https://github.com/MobilityData/gtfs.org/blob/master/README.md).
+Thank you to [Andrew Byrd](https://www.linkedin.com/in/byrdandrew) for purchasing and lending use of the GTFS.org domain name and providing leadership for the community.
 
-To propose a feature, content addition, or UI/UX improvement, open an [issue](https://github.com/MobilityData/gtfs.org/issues/new) in the gtfs.org repository.
+<br>
 
-## License
+**License**
 
 Except as otherwise noted, the content of this site is licensed under the [Creative Commons Attribution 3.0 License](https://creativecommons.org/licenses/by/3.0/), and code samples are licensed under the [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).
-
-## Contact
 
 For more information, contact [documentation@mobilitydata.org](mailto:documentation@mobilitydata.org).

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,26 +1,19 @@
 # About
 
-GTFS.org is maintained by [MobilityData](https://mobilitydata.org/), a Canadian non-profit that aims to broaden adoption and increase the functionality of the GTFS & GBFS data formats. Thank you to [Andrew Byrd](https://www.linkedin.com/in/byrdandrew) for purchasing and lending use of the gtfs.org domain name and providing leadership for the GTFS community.
+gtfs.org is a central platform presenting documentation on GTFS. The content on this site is maintained by [MobilityData](https://mobilitydata.org/).
 
-For more information, contact [documentation@mobilitydata.org](mailto:documentation@mobilitydata.org).
-
-## MobilityData
-
-MobilityData began in 2015 as a Rocky Mountain Institute project with the mission to improve travelers' information. It extended its mission and reach by becoming a Canadian non-profit in 2019 and a French one in 2021. The MobilityData team includes a number of transportation thinkers and technical experts. With over 20 employees worldwide, MobilityData brings together and supports international mobility stakeholders such as transport agencies, software vendors, mobility apps, and cities to standardize and expand data formats such as GTFS and GBFS for public transport and shared mobility. MobilityData acts as an industry facilitator, creating opportunities for strengthened interoperability while assisting the industry’s rapid transformation through training and tools. 
-
-Learn more at [mobilitydata.org](https://mobilitydata.org/).
-
-<a href="https://mobilitydata.org/" target="_blank" rel="noopener" alt="MobilityData">
-    <img src="../assets/md-black.svg#only-light" width=150rem style="float: left">
-    <img src="../assets/md-white.svg#only-dark" width=150rem style="float: left">
-</a><br><br>
+Thank you to [Andrew Byrd](https://www.linkedin.com/in/byrdandrew) for the leadership in establishing gtfs.org and the ongoing use of this domain name.
 
 ## Editing this site
 
 The GTFS Documentation Platform is based on open source content pulled from various repositories. To propose edits to content, open an issue or pull request in the respective source-of-truth repository found in the [README](https://github.com/MobilityData/gtfs.org/blob/master/README.md).
 
-To propose a feature, content addition, or UI/UX improvement, open an [issue](https://github.com/MobilityData/gtfs.org/issues/new) in the GTFS.org repository.
+To propose a feature, content addition, or UI/UX improvement, open an [issue](https://github.com/MobilityData/gtfs.org/issues/new) in the gtfs.org repository.
 
 ## License
 
 Except as otherwise noted, the content of this site is licensed under the [Creative Commons Attribution 3.0 License](https://creativecommons.org/licenses/by/3.0/), and code samples are licensed under the [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).
+
+## Contact
+
+For more information, contact [documentation@mobilitydata.org](mailto:documentation@mobilitydata.org).


### PR DESCRIPTION
A few suggested changes to improve the readability of this page:
- Added description of gtfs.org sentence.
- Removed content on MobilityData, users can follow the link to find specific info on mobilitydata.org.
- Moved contact to a dedicated header for clarity.