### PR TITLE
Create deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,18 @@
+name: build
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+        env:
+          MKDOCS_TOKEN: ${{ secrets.MKDOCS_TOKEN }}
+      - run: pip install -r requirements.txt
+      - run: pip install git+https://$MKDOCS_TOKEN@github.com/squidfunk/mkdocs-material-insiders.git==4.21.0
+      - run: mkdocs gh-deploy --force --clean --verbose


### PR DESCRIPTION
Add workflow to deploy the website upon new merges to main. 

Requires:
- requirements.txt
- `MKDOCS_TOKEN` environment secret setup in this repository

To fix:
- [ ] Securely install `mkdocs-material-insiders` with token (currently unauthorized with current configuration due to printing of secret directly in workflow)