### PR TITLE
fix traditional chinese translation

### DIFF
--- a/docs/index.zh_TW.md
+++ b/docs/index.zh_TW.md
@@ -9,9 +9,9 @@ search:
     <a class="button" href="schedule">GTFS Schedule</a><a class="button" href="realtime">GTFS Realtime</a><a class="button" href="resources">資源</a><a class="button" href="extensions">擴展</a>
 </div>
 
-这General Transit Feed Specification (GTFS) 是一种数据规范，允许公共交通机构以[多种软件应用程序](resources/apps)可以使用的格式发布其交通数据。今天，GTFS数以千计的公共交通提供商使用数据格式。
+這General Transit Feed Specification (GTFS) 是一種數據規範，允許公共交通機構以[多種軟件應用程序](resources/apps)可以使用的格式發布其交通數據。今天，GTFS數以千計的公共交通提供商使用數據格式。
 
 
-GTFS被分成一个Schedule包含的[组件](schedule)Schedule、票价和地理交通信息以及包含到达预测、车辆位置和服务建议[的实时组件](realtime)。
+GTFS被分成一個Schedule包含的[組件](schedule)Schedule、票價和地理交通信息以及包含到達預測、車輛位置和服務建議[的實時組件](realtime)。
 
 [更多的GTFS背景](background.md)

--- a/docs/realtime/best-practices.zh_TW.md
+++ b/docs/realtime/best-practices.zh_TW.md
@@ -3,159 +3,159 @@ search:
   exclude: true
 ---
   
-# GTFS Realtime 最佳实践
+# GTFS Realtime 最佳實踐
 
-## 介绍
+## 介紹
 
-这些是描述实时公共交通信息的推荐做法GTFS Realtime数据格式。
+這些是描述實時公共交通信息的推薦做法GTFS Realtime數據格式。
 
-### 文件结构
+### 文件結構
 
-推荐的做法分为两个主要部分
+推薦的做法分為兩個主要部分
 
-* __[实践建议组织者](#practice-recommendations-organized-by-message)__message__:__推荐由message和字段按照官方描述的相同顺序GTFS Realtime参考。
-* __[按案例组织的实践建议](#practice-recommendations-organized-by-use-case)：__对于特定案例，例如基于频率的服务（与基于时间表的服务），实践可能需要应用于多个消息和字段以及相应的GTFS Schedule数据。此类建议合并在本节中。
+* __[實踐建議組織者](#practice-recommendations-organized-by-message)__message__:__推薦由message和字段按照官方描述的相同順序GTFS Realtime參考。
+* __[按案例組織的實踐建議](#practice-recommendations-organized-by-use-case)：__對於特定案例，例如基於頻率的服務（與基於時間表的服務），實踐可能需要應用於多個消息和字段以及相應的GTFS Schedule數據。此類建議合併在本節中。
 
-### 饲料发布和一般实践
+### 飼料發布和一般實踐
 
-* 提要应在公开的、永久的url
-* 这url应该可以直接访问，而无需登录即可访问提要。如果需要，可以使用 API 密钥，但 API 密钥的注册应该是自动化的并且对所有人都可用。
-* 维护持久标识符 (id字段）内GTFS Realtime饲料（例如，FeedEntity.id ,VehicleDescriptor.id ,CarriageDetails.id ) 跨提要迭代。
-* GTFS Realtime提要应至少每 30 秒刷新一次，或者每当提要中表示的信息 (Position一个vehicle) 更改，以较频繁者为准。 VehiclePositions 往往比其他提要实体更频繁地更改，应尽可能频繁地更新。如果内容未更改，则应使用新的更新FeedHeader `FeedHeader . timestamp`timestamp反映该信息仍然相关timestamp.
-* 一个内的数据GTFS Realtime饲料不应超过 90 秒trip更新和vehicle服务警报的位置和不超过 10 分钟。例如，即使生产者不断刷新FeedHeader `FeedHeader . timestamp`timestamptimestamp每 30 秒，该提要中的 VehiclePosition 的年龄不应超过 90 秒。
-* 服务器托管GTFS Realtime数据应该是可靠的，并且始终返回格式有效的 protobuf 编码响应。少于 1% 的响应应该是无效的（protobuf 错误或获取错误）。
-* 网络服务器托管GTFS Realtime数据应配置为正确报告文件修改日期（参见 HTTP/1.1 - Request for Comments 2616，在第 14.29 节下），以便消费者可以利用`If-Modified-Since` HTTPheader.这通过避免传输未更改的提要内容来节省生产者和消费者的带宽。
-* 当通过给定的 HTTP 请求进行查询时，Feed 应默认提供协议缓冲区编码的 Feed 内容url- 消费者不需要定义特殊的 HTTP 接受标头来接收协议缓冲区编码的内容。
-* 由于协议缓冲区如何对[可选值](https://developers.google.com/protocol-buffers/docs/proto#optional)进行编码，因此在从GTFS Realtime提要消费者应在使用该值之前使用协议缓冲区生成的`hasX()`方法检查值的存在，并且仅应在`hasX()`为真（其中`X`是字段的名称）时使用该值。如果`hasX()`返回`false` ，则该字段的默认值在GTFS应该假设`GTFS -realtime.proto`值。如果消费者在没有首先检查`hasX()`方法的情况下使用该值，则它可能正在读取生产者无意发布的默认数据。
-* Feed 应使用 HTTPS 而不是 HTTP（不加密）以确保 Feed 完整性。
-* 提要应涵盖伴随静态中包含的绝大多数行程GTFS数据集。特别是，它应该包括高密度和高流量的城市地区和繁忙路线的数据。
+* 提要應在公開的、永久的url
+* 這url應該可以直接訪問，而無需登錄即可訪問提要。如果需要，可以使用 API 密鑰，但 API 密鑰的註冊應該是自動化的並且對所有人都可用。
+* 維護持久標識符 (id字段）內GTFS Realtime飼料（例如，FeedEntity.id ,VehicleDescriptor.id ,CarriageDetails.id ) 跨提要迭代。
+* GTFS Realtime提要應至少每 30 秒刷新一次，或者每當提要中表示的信息 (Position一個vehicle) 更改，以較頻繁者為準。 VehiclePositions 往往比其他提要實體更頻繁地更改，應盡可能頻繁地更新。如果內容未更改，則應使用新的更新FeedHeader `FeedHeader . timestamp`timestamp反映該信息仍然相關timestamp.
+* 一個內的數據GTFS Realtime飼料不應超過 90 秒trip更新和vehicle服務警報的位置和不超過 10 分鐘。例如，即使生產者不斷刷新FeedHeader `FeedHeader . timestamp`timestamptimestamp每 30 秒，該提要中的 VehiclePosition 的年齡不應超過 90 秒。
+* 服務器託管GTFS Realtime數據應該是可靠的，並且始終返回格式有效的 protobuf 編碼響應。少於 1% 的響應應該是無效的（protobuf 錯誤或獲取錯誤）。
+* 網絡服務器託管GTFS Realtime數據應配置為正確報告文件修改日期（參見 HTTP/1.1 - Request for Comments 2616，在第 14.29 節下），以便消費者可以利用`If-Modified-Since` HTTPheader.這通過避免傳輸未更改的提要內容來節省生產者和消費者的帶寬。
+* 當通過給定的 HTTP 請求進行查詢時，Feed 應默認提供協議緩衝區編碼的 Feed 內容url- 消費者不需要定義特殊的 HTTP 接受標頭來接收協議緩衝區編碼的內容。
+* 由於協議緩衝區如何對[可選值](https://developers.google.com/protocol-buffers/docs/proto#optional)進行編碼，因此在從GTFS Realtime提要消費者應在使用該值之前使用協議緩衝區生成的`hasX()`方法檢查值的存在，並且僅應在`hasX()`為真（其中`X`是字段的名稱）時使用該值。如果`hasX()`返回`false` ，則該字段的默認值在GTFS應該假設`GTFS -realtime.proto`值。如果消費者在沒有首先檢查`hasX()`方法的情況下使用該值，則它可能正在讀取生產者無意發布的默認數據。
+* Feed 應使用 HTTPS 而不是 HTTP（不加密）以確保 Feed 完整性。
+* 提要應涵蓋伴隨靜態中包含的絕大多數行程GTFS數據集。特別是，它應該包括高密度和高流量的城市地區和繁忙路線的數據。
 
-## 实践建议组织者message
+## 實踐建議組織者message
 
 ### FeedHeader
 
-| 字段名称                    | 推荐                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| 字段名稱                    | 推薦                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `gtfs_realtime_version` | 当前版本是“2.0”。全部GTFS Realtime提要应该是“2.0”或更高版本，作为早期版本GTFS Realtime不需要所有字段来充分代表各种过境情况。                                                                                                                                                                                                                                                                                                                                        |
-| `timestamp`             | 这个timestamp在两个连续的馈送迭代之间不应减少。                                                                                                                                                                                                                                                                                                                                                                                            |
-|                         | 这个timestamp如果提要内容更改，则值应始终更改 - 提要内容不应在不更新header`timestamp` .<br/><br/>*常见错误*- 如果有多个实例GTFS Realtime在负载均衡器后面馈送，每个实例可能会从实时数据源中提取信息并将其发布给稍微不同步的消费者。如果一个GTFS Realtime消费者发出两个背靠背请求，每个请求由不同的GTFS Realtimefeed 实例，相同的 feed 内容可能会以不同的时间戳返回给消费者。<br/><br/>*可能的解决方案*- 生产者应提供`Last-Modified`HTTPheader, 消费者应该通过他们最近的`If-Modified-Since`HTTPheader以避免收到过时的数据。<br/><br/>*可能的解决方案* - 如果无法使用 HTTP 标头，则可以使用粘性会话等选项来确保每个消费者都被路由到同一个生产者服务器。 |
+| `gtfs_realtime_version` | 當前版本是“2.0”。全部GTFS Realtime提要應該是“2.0”或更高版本，作為早期版本GTFS Realtime不需要所有字段來充分代表各種過境情況。 |
+| `timestamp`             | 這個timestamp在兩個連續的饋送迭代之間不應減少。 |
+|                         | 這個timestamp如果提要內容更改，則值應始終更改 - 提要內容不應在不更新header`timestamp` .<br/><br/>*常見錯誤*- 如果有多個實例GTFS Realtime在負載均衡器後面饋送，每個實例可能會從實時數據源中提取信息並將其發布給稍微不同步的消費者。如果一個GTFS Realtime消費者發出兩個背靠背請求，每個請求由不同的GTFS Realtimefeed 實例，相同的 feed 內容可能會以不同的時間戳返回給消費者。 <br/><br/>*可能的解決方案*- 生產者應提供`Last-Modified`HTTPheader, 消費者應該通過他們最近的`If-Modified-Since`HTTPheader以避免收到過時的數據。 <br/><br/>*可能的解決方案* - 如果無法使用 HTTP 標頭，則可以使用粘性會話等選項來確保每個消費者都被路由到同一個生產者服務器。 |
 
 ### FeedEntity
 
-所有实体只能从GTFS Realtime当它们不再与用户相关时提供。提要被认为是无状态的，这意味着每个提要都反映了整个真实的time公交系统的状态。如果entity在一个提要实例中提供，但在随后的提要更新中删除，应该假设没有真正的-time相关信息entity.
+所有實體只能從GTFS Realtime當它們不再與用戶相關時提供。提要被認為是無狀態的，這意味著每個提要都反映了整個真實的time公交系統的狀態。如果entity在一個提要實例中提供，但在隨後的提要更新中刪除，應該假設沒有真正的-time相關信息entity.
 
-| 字段名称 | 推荐                 |
+| 字段名稱 | 推薦                 |
 | ---- | ------------------ |
-| `id` | 应该在整个过程中保持稳定trip期间 |
+| `id` | 應該在整個過程中保持穩定trip期間 |
 
 ### TripUpdate
 
-一般准则trip取消：
+一般準則trip取消：
 
-* 当取消几天内的旅行时，生产者应提供引用给定`trip_ids`和`start_dates`的 TripUpdates 作为CANCELED以及一个Alert和NO_SERVICE引用相同的`trip_ids`和TimeRange可以显示给乘客解释取消（例如，DETOUR）。
-* 如果没有停止trip将被访问，trip应该CANCELED而不是将所有`stop_time_updates`标记为SKIPPED .
+* 當取消幾天內的旅行時，生產者應提供引用給定`trip_ids`和`start_dates`的 TripUpdates 作為CANCELED以及一個Alert和NO_SERVICE引用相同的`trip_ids`和TimeRange可以顯示給乘客解釋取消（例如，DETOUR）。
+* 如果沒有停止trip將被訪問，trip應該CANCELED而不是將所有`stop_time_updates`標記為SKIPPED .
 
-| 字段名称               | 推荐                                                                                                                                                                                                                                                                                                                       |
+| 字段名稱               | 推薦                                                                                                                                                                                                                                                                                                                       |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `trip`             | 参考[messageTripDescriptor](#TripDescriptor) .                                                                                                                                                                                                                                                                             |
-|                    | 如果分开`VehiclePosition`和`TripUpdate`提供饲料，[TripDescriptor](#TripDescriptor)和[VehicleDescriptor](#VehicleDescriptor)id值配对应该在两个提要之间匹配。<br/><br/>例如，一个`VehiclePosition`entity有`vehicle_id:A`和`trip_id:4`, 那么对应的`TripUpdate`entity也应该有`vehicle_id:A`和`trip_id:4`.如果有的话`TripUpdate`entity有`trip_id:4`和任何`vehicle_id`除了 4，这是一个错误。 |
-| `vehicle`          | 参考[messageVehicleDescriptor](#VehicleDescriptor) .                                                                                                                                                                                                                                                                       |
-|                    | 如果分开`VehiclePosition`和`TripUpdate`提供饲料，[TripDescriptor](#TripDescriptor)和[VehicleDescriptor](#VehicleDescriptor)id值配对应该在两个提要之间匹配。<br/><br/>例如，一个`VehiclePosition`entity有`vehicle_id:A`和`trip_id:4`, 那么对应的`TripUpdate`entity也应该有`vehicle_id:A`和`trip_id:4`.如果有的话`TripUpdate`entity有`trip_id:4`和任何`vehicle_id`除了 4，这是一个错误。 |
-| `stop_time_update` | `stop_time_updates`对于给定的`trip_id`应严格按照增加顺序`stop_sequence`和不`stop_sequence`应该重复。                                                                                                                                                                                                                                          |
-|                    | 虽然trip正在进行中，所有`TripUpdates`应至少包括一个`stop_time_update`与预测arrival或者departuretime在将来。请注意，[GTFS Realtime规格](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/trip-updates.md#stop-time-updates)说生产者不应该放弃过去`StopTimeUpdate`如果它指的是一个停止SCHEDULEDarrivaltime在给定的未来trip（即vehicle已提前通过该站点），否则将得出该站点没有更新的结论。      |
-| `timestamp`        | 应反映time这个预测trip已更新。                                                                                                                                                                                                                                                                                                      |
-| `delay`            | `TripUpdate.delay`应该表示进度偏差，即观察到的过去值如何提前/落后于进度vehicle是。应通过以下方式提供对未来停靠点的预测`StopTimeEvent.delay`或者`StopTimeEvent.time` .                                                                                                                                                                                                    |
+| `trip`             | 參考[messageTripDescriptor](#TripDescriptor) .                                                                                                                                                                                                                                                                             |
+|                    | 如果分開`VehiclePosition`和`TripUpdate`提供飼料，[TripDescriptor](#TripDescriptor)和[VehicleDescriptor](#VehicleDescriptor)id值配對應該在兩個提要之間匹配。 <br/><br/>例如，一個`VehiclePosition`entity有`vehicle_id:A`和`trip_id:4`, 那麼對應的`TripUpdate`entity也應該有`vehicle_id:A`和`trip_id:4`.如果有的話`TripUpdate`entity有`trip_id:4`和任何`vehicle_id`除了 4，這是一個錯誤。 |
+| `vehicle`          | 參考[messageVehicleDescriptor](#VehicleDescriptor) .                                                                                                                                                                                                                                                                       |
+|                    | 如果分開`VehiclePosition`和`TripUpdate`提供飼料，[TripDescriptor](#TripDescriptor)和[VehicleDescriptor](#VehicleDescriptor)id值配對應該在兩個提要之間匹配。 <br/><br/>例如，一個`VehiclePosition`entity有`vehicle_id:A`和`trip_id:4`, 那麼對應的`TripUpdate`entity也應該有`vehicle_id:A`和`trip_id:4`.如果有的話`TripUpdate`entity有`trip_id:4`和任何`vehicle_id`除了 4，這是一個錯誤。 |
+| `stop_time_update` | `stop_time_updates`對於給定的`trip_id`應嚴格按照增加順序`stop_sequence`和不`stop_sequence`應該重複。 |
+|                    | 雖然trip正在進行中，所有`TripUpdates`應至少包括一個`stop_time_update`與預測arrival或者departuretime在將來。請注意，[GTFS Realtime規格](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/trip-updates.md#stop-time-updates)說生產者不應該放棄過去`StopTimeUpdate`如果它指的是一個停止SCHEDULEDarrivaltime在給定的未來trip（即vehicle已提前通過該站點），否則將得出該站點沒有更新的結論。 |
+| `timestamp`        | 應反映time這個預測trip已更新。 |
+| `delay`            | `TripUpdate.delay`應該表示進度偏差，即觀察到的過去值如何提前/落後於進度vehicle是。應通過以下方式提供對未來停靠點的預測`StopTimeEvent.delay`或者`StopTimeEvent.time` .                                                                                                                                                                                                    |
 
 ### TripDescriptor
 
-如果分开VehiclePosition和TripUpdate提供饲料，TripDescriptor和VehicleDescriptorid值配对应该在两个提要之间匹配。
+如果分開VehiclePosition和TripUpdate提供飼料，TripDescriptor和VehicleDescriptorid值配對應該在兩個提要之間匹配。
 
-例如，一个VehiclePositionentity有`vehicle_id:A`和trip_id `trip_id :4` ，那么对应的TripUpdateentity还应该有`vehicle_id:A`和trip_id `trip_id :4` 。
+例如，一個VehiclePositionentity有`vehicle_id:A`和trip_id `trip_id :4` ，那麼對應的TripUpdateentity還應該有`vehicle_id:A`和trip_id `trip_id :4` 。
 
-| 字段名称                    | 推荐                        |
+| 字段名稱                    | 推薦                        |
 | ----------------------- | ------------------------- |
-| `schedule_relationship` | 的行为`ADDED`行程未指定，不推荐使用此枚举。 |
+| `schedule_relationship` | 的行為`ADDED`行程未指定，不推薦使用此枚舉。 |
 
 ### VehicleDescriptor
 
-如果分开VehiclePosition和TripUpdate提供饲料，TripDescriptor和VehicleDescriptorid值配对应该在两个提要之间匹配。
+如果分開VehiclePosition和TripUpdate提供飼料，TripDescriptor和VehicleDescriptorid值配對應該在兩個提要之間匹配。
 
-例如，一个VehiclePositionentity有`vehicle_id:A`和trip_id `trip_id :4` ，那么对应的TripUpdateentity还应该有`vehicle_id:A`和trip_id `trip_id :4` 。
+例如，一個VehiclePositionentity有`vehicle_id:A`和trip_id `trip_id :4` ，那麼對應的TripUpdateentity還應該有`vehicle_id:A`和trip_id `trip_id :4` 。
 
-| 字段名称 | 推荐                           |
+| 字段名稱 | 推薦                           |
 | ---- | ---------------------------- |
-| `id` | 应该唯一且稳定地识别一个vehicle在整个trip期间 |
+| `id` | 應該唯一且穩定地識別一個vehicle在整個trip期間 |
 
 ### StopTimeUpdate
 
-| 字段名称            | 推荐                                                                                                                                   |
+| 字段名稱            | 推薦                                                                                                                                   |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `stop_sequence` | 提供`stop_sequence`只要有可能，因为它明确地解析为GTFS停止time在`stop_times.txt`不像`stop_id`, 这可能在一个trip（例如，循环路线）。                                         |
-| `arrival`       | arrival连续停止之间的时间应该增加 - 它们不应该相同或减少。                                                                                                   |
-|                 | arrival`time`（指定在[StopTimeEvent](#StopTimeEvent)) 应该在departure`time`如果中途停留或停留，则为同一站点time预计 - 否则，arrival`time`应该是一样的departure`time` . |
-| `departure`     | departure连续停止之间的时间应该增加 - 它们不应该相同或减少。                                                                                                 |
-|                 | departure`time`（指定在[StopTimeEvent](#StopTimeEvent)) 应与arrival`time`如果没有中途停留或停留，则为同一站time预计 - 否则，departure`time`应该在之后arrival`time`.   |
+| `stop_sequence` | 提供`stop_sequence`只要有可能，因為它明確地解析為GTFS停止time在`stop_times.txt`不像`stop_id`, 這可能在一個trip（例如，循環路線）。 |
+| `arrival`       | arrival連續停止之間的時間應該增加 - 它們不應該相同或減少。 |
+|                 | arrival`time`（指定在[StopTimeEvent](#StopTimeEvent)) 應該在departure`time`如果中途停留或停留，則為同一站點time預計 - 否則，arrival`time`應該是一樣的departure`time` . |
+| `departure`     | departure連續停止之間的時間應該增加 - 它們不應該相同或減少。 |
+|                 | departure`time`（指定在[StopTimeEvent](#StopTimeEvent)) 應與arrival`time`如果沒有中途停留或停留，則為同一站time預計 - 否則，departure`time`應該在之後arrival`time`.   |
 
 ### StopTimeEvent
 
-| 字段名称    | 推荐                                                                                                                                                                                                                                                    |
+| 字段名稱    | 推薦                                                                                                                                                                                                                                                    |
 | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `delay` | 要是`delay`提供在一个`stop_time_update` `arrival`或者`departure`（并不是`time`)，那么GTFS[`stop_times.txt`](https://gtfs.org/reference/static#stopstxt)应该包含`arrival_times`和/或`departure_times`对于这些相应的站点。一个`delay`除非您有时钟，否则实时提要中的值毫无意义time将其添加到GTFS`stop_times.txt`文件。 |
+| `delay` | 要是`delay`提供在一個`stop_time_update` `arrival`或者`departure`（並不是`time`)，那麼GTFS[`stop_times.txt`](https://gtfs.org/reference/static#stopstxt)應該包含`arrival_times`和/或`departure_times`對於這些相應的站點。一個`delay`除非您有時鐘，否則實時提要中的值毫無意義time將其添加到GTFS`stop_times.txt`文件。 |
 
 ### VehiclePosition
 
-以下是应包含在 VehiclePostions 提要中的推荐字段，以便为消费者提供高质量数据（例如，用于生成预测）
+以下是應包含在 VehiclePostions 提要中的推薦字段，以便為消費者提供高質量數據（例如，用於生成預測）
 
-| 字段名称                 | 笔记                                                                                                        |
+| 字段名稱                 | 筆記                                                                                                        |
 | -------------------- | --------------------------------------------------------------------------------------------------------- |
-| `entity.id`          | 应该在整个过程中保持稳定trip期间                                                                                        |
-| `vehicle.timestamp`  | 提供timestamp在哪个vehiclePosition强烈建议进行测量。否则，消费者必须使用messagetimestamp，这可能会给骑手带来误导性的结果message比个人更频繁地更新Position. |
-| `vehicle.vehicle.id` | 应该唯一且稳定地识别一个vehicle在整个trip期间                                                                              |
+| `entity.id`          | 應該在整個過程中保持穩定trip期間                                                                                        |
+| `vehicle.timestamp`  | 提供timestamp在哪個vehiclePosition強烈建議進行測量。否則，消費者必須使用messagetimestamp，這可能會給騎手帶來誤導性的結果message比個人更頻繁地更新Position. |
+| `vehicle.vehicle.id` | 應該唯一且穩定地識別一個vehicle在整個trip期間                                                                              |
 
 ### Position
 
-这vehiclePosition应在 200 米范围内GTFSshapes.txt当前的数据trip除非有一个Alert与Effect的DETOUR为了这trip_id .
+這vehiclePosition應在 200 米範圍內GTFSshapes.txt當前的數據trip除非有一個Alert與Effect的DETOUR為了這trip_id .
 
 ### Alert
 
-警报的一般准则：
+警報的一般準則：
 
-* 什么时候trip_id和start_time在`exact_time=1`区间内，start_time应该比间隔的开始晚一个精确的倍数`headway_secs` 。
-* 当取消几天内的旅行时，生产者应提供引用给定`trip_ids`和`start_dates`的 TripUpdates 作为CANCELED以及一个Alert和NO_SERVICE引用相同的`trip_ids`和TimeRange可以显示给乘客解释取消（例如，DETOUR）。
-* 如果Alert影响一条线上的所有停靠点，使用基于线的Alert而不是基于停止的Alert.不要应用Alert到线路的每一站。
-* 虽然服务提醒没有字符限制，但公交乘客通常会在移动设备上查看提醒。请简明扼要。
+* 什麼時候trip_id和start_time在`exact_time=1`區間內，start_time應該比間隔的開始晚一個精確的倍數`headway_secs` 。
+* 當取消幾天內的旅行時，生產者應提供引用給定`trip_ids`和`start_dates`的 TripUpdates 作為CANCELED以及一個Alert和NO_SERVICE引用相同的`trip_ids`和TimeRange可以顯示給乘客解釋取消（例如，DETOUR）。
+* 如果Alert影響一條線上的所有停靠點，使用基於線的Alert而不是基於停止的Alert.不要應用Alert到線路的每一站。
+* 雖然服務提醒沒有字符限制，但公交乘客通常會在移動設備上查看提醒。請簡明扼要。
 
-| 字段名称               | 推荐                    |
+| 字段名稱               | 推薦                    |
 | ------------------ | --------------------- |
-| `description_text` | 使用换行符使您的服务Alert更容易阅读。 |
+| `description_text` | 使用換行符使您的服務Alert更容易閱讀。 |
 
-## 按用例组织的实践建议
+## 按用例組織的實踐建議
 
-### 基于频率的旅行
+### 基於頻率的旅行
 
-基于频率的trip不遵循固定的时间表，而是试图保持预定的进度。这些行程在[GTFS](<https://\<glossary variable=>)中表示[.org/reference/static/#frequenciestxt">](<https://\<glossary variable=>)GTFS [frequency.txt](<https://\<glossary variable=>)通过设置`exact_times=0`或省略`exact_times`字段（注意`exact_times=1`行程*不是*基于频率的行程-frequencies.txt使用`exact_times=1`只是作为一种方便的方法，以更紧凑的方式存储基于时间表的行程）。构建时需要牢记几个最佳实践GTFS Realtime用于基于频率的旅行的提要。
+基於頻率的trip不遵循固定的時間表，而是試圖保持預定的進度。這些行程在[GTFS](<https://\<glossary variable=>)中表示[.org/reference/static/#frequenciestxt">](<https://\<glossary variable=>)GTFS [frequency.txt](<https://\<glossary variable=>)通過設置`exact_times=0`或省略`exact_times`字段（注意`exact_times=1`行程*不是*基於頻率的行程-frequencies.txt使用`exact_times=1`只是作為一種方便的方法，以更緊湊的方式存儲基於時間表的行程）。構建時需要牢記幾個最佳實踐GTFS Realtime用於基於頻率的旅行的提要。
 
-* 在TripUpdate[.](#StopTimeUpdate)StopTimeUpdate， 这StopTimeEvent为了arrival和departure不应包含delay因为基于频率的旅行不遵循固定的时间表。反而，time应提供以表明arrival/departure预测。
+* 在TripUpdate[.](#StopTimeUpdate)StopTimeUpdate， 這StopTimeEvent為了arrival和departure不應包含delay因為基於頻率的旅行不遵循固定的時間表。反而，time應提供以表明arrival/departure預測。
 
-* 根据规范的要求，在描述时trip在TripUpdate或者VehiclePosition通过使用TripDescriptor， 所有的trip_id ,start_time ， 和start_date必须提供。此外，schedule_relationship应该UNSCHEDULED .
+* 根據規範的要求，在描述時trip在TripUpdate或者VehiclePosition通過使用TripDescriptor， 所有的trip_id ,start_time ， 和start_date必須提供。此外，schedule_relationship應該UNSCHEDULED .
 
-（例如，重新执法旅行）。
+（例如，重新執法旅行）。
 
-## 关于本文档
+## 關於本文檔
 
-### 目标
+### 目標
 
-维护的目标GTFS Realtime最佳实践是：
+維護的目標GTFS Realtime最佳實踐是：
 
-* 提升end- 公共交通应用程序中的用户客户体验
-* 让软件开发人员更轻松地部署和扩展应用程序、产品和服务
+* 提升end- 公共交通應用程序中的用戶客戶體驗
+* 讓軟件開發人員更輕鬆地部署和擴展應用程序、產品和服務
 
-### 如何提出或修改已发表GTFS Realtime最佳实践
+### 如何提出或修改已發表GTFS Realtime最佳實踐
 
-GTFS应用程序和实践不断发展，因此本文档可能需要从time至time.要对本文档提出修改建议，请[在](https://github.com/MobilityData/GTFS_Realtime_Best-Practices)GTFS Realtime[最佳实践 GitHub 存储库](https://github.com/MobilityData/GTFS_Realtime_Best-Practices)并倡导变革。
+GTFS應用程序和實踐不斷發展，因此本文檔可能需要從time至time.要對本文檔提出修改建議，請[在](https://github.com/MobilityData/GTFS_Realtime_Best-Practices)GTFS Realtime[最佳實踐 GitHub 存儲庫](https://github.com/MobilityData/GTFS_Realtime_Best-Practices)並倡導變革。
 
-### 链接到此文档
+### 鏈接到此文檔
 
-请在此处链接，以便为饲料生产商提供正确形成的指导GTFS Realtime数据。每个单独的推荐都有一个锚链接。点击推荐获取url对于页内锚链接。
+請在此處鏈接，以便為飼料生產商提供正確形成的指導GTFS Realtime數據。每個單獨的推薦都有一個錨鏈接。點擊推薦獲取url對於頁內錨鏈接。
 
-如果一个GTFS Realtime- 消费应用程序提出要求或建议GTFS Realtime对于此处未描述的数据实践，建议发布包含这些要求或建议的文档，以补充这些常见的最佳实践。
+如果一個GTFS Realtime- 消費應用程序提出要求或建議GTFS Realtime對於此處未描述的數據實踐，建議發布包含這些要求或建議的文檔，以補充這些常見的最佳實踐。

--- a/docs/realtime/index.zh_TW.md
+++ b/docs/realtime/index.zh_TW.md
@@ -13,22 +13,22 @@ search:
 
 為用戶提供實時的公交數據更新，極大地提升了他們對您的公交服務的體驗。提供有關當前到達和離開時間的最新信息使用戶能夠順利地計劃他們的旅行。結果，萬一不幸延誤，騎手知道他們可以在家裡多呆一會兒會鬆一口氣。
 
-GTFS Realtime 是一种提要规范，允许公共交通机构向应用程序开发人员提供有关其车队的实时更新。它是[GTFS](../schedule/reference) （通用交通馈送规范）的扩展，是一种用于公共交通时刻表和相关地理信息的开放数据格式。 GTFS Realtime 是围绕易于实施、良好的 GTFS 互操作性和对乘客信息的关注而设计的。
+GTFS Realtime 是一種提要規範，允許公共交通機構向應用程序開發人員提供有關其車隊的實時更新。它是[GTFS](../schedule/reference) （通用交通饋送規範）的擴展，是一種用於公共交通時刻表和相關地理信息的開放數據格式。 GTFS Realtime 是圍繞易於實施、良好的 GTFS 互操作性和對乘客信息的關注而設計的。
 
-该规范是通过最初的[实时交通更新](https://developers.google.com/transit/google-transit#LiveTransitUpdates)合作伙伴机构、一些交通开发商和谷歌的合作设计的。该规范是在[Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html)下发布的。
+該規範是通過最初的[實時交通更新](https://developers.google.com/transit/google-transit#LiveTransitUpdates)合作夥伴機構、一些交通開發商和谷歌的合作設計的。該規範是在[Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html)下發布的。
 
 ## 我該如何開始？
 
-1.  继续阅读下面的概述。
-2.  决定您将提供哪些[提要实体](feed-entities)。
+1.  繼續閱讀下面的概述。
+2.  決定您將提供哪些[提要實體](feed-entities)。
 3.  看看[示例提要](feed-examples)。
 4.  使用[参考](reference)创建您自己的提要。
-5.  [发布您的提要](best-practices/#feed-publishing-general-practices)。
+5.  [發布您的提要](best-practices/#feed-publishing-general-practices)。
 
 
-## 的概述 GTFS Realtime 饲料
+## 的概述 GTFS Realtime 飼料
 
-该规范目前支持以下类型的信息：
+該規範目前支持以下類型的信息：
 
 *   **行程更新** - 延誤、取消、更改路線
 *   **服務警報** - 停止移動、影響車站、路線或整個網絡的不可預見事件
@@ -36,7 +36,7 @@ GTFS Realtime 是一种提要规范，允许公共交通机构向应用程序开
 
 一個提要可以（儘管不是必需的）組合不同類型的實體。提要通過 HTTP 提供並經常更新。該文件本身是一個常規的二進製文件，因此任何類型的網絡服務器都可以託管和提供該文件（也可以使用其他傳輸協議）。或者，也可以使用 Web 應用程序服務器，它作為對有效 HTTP GET 請求的響應將返回提要。對於更新或檢索提要的頻率和確切方法沒有限制。
 
-因为GTFSRealtime允许您展示车队的_实际_状态，需要定期更新提要 - 最好是每当新数据来自您的自动车辆定位系统时。
+因為GTFSRealtime允許您展示車隊的_實際_狀態，需要定期更新提要 - 最好是每當新數據來自您的自動車輛定位系統時。
 
 [有關提要實體的更多信息...](feed-entities)
 

--- a/docs/realtime/reference.zh_TW.md
+++ b/docs/realtime/reference.zh_TW.md
@@ -3,45 +3,45 @@ search:
   exclude: true
 ---
   
-# GTFS Realtime 参考
+# GTFS Realtime 參考
 
-一个GTFS RealtimeFeed 让公交机构可以向消费者提供有关其服务中断（车站关闭、线路未运行、重要延误等）车辆位置和预期的实时信息arrival次。
+一個GTFS RealtimeFeed 讓公交機構可以向消費者提供有關其服務中斷（車站關閉、線路未運行、重要延誤等）車輛位置和預期的實時信息arrival次。
 
-提要规范的 2.0 版在此站点上进行了讨论和记录。有效版本为“2.0”、“1.0”。
+提要規範的 2.0 版在此站點上進行了討論和記錄。有效版本為“2.0”、“1.0”。
 
-### 术语定义
+### 術語定義
 
 #### 必需的
 
-在GTFS -realtime v2.0 及更高版本，*必填*列描述了生产者必须提供哪些字段才能使传输数据有效并对消费应用程序有意义。
+在GTFS -realtime v2.0 及更高版本，*必填*列描述了生產者必須提供哪些字段才能使傳輸數據有效並對消費應用程序有意義。
 
 在*必填*字段中使用以下值：
 
-*   **必填**：此字段必须由GTFS - 实时饲料生产者。
-*   **有条件要求**：此字段在某些条件下是必需的，在字段*Description*中进行了概述。在这些条件之外，该字段是可选的。
-*   **可选**：该字段是可选的，生产者不需要实现。但是，如果数据在基础自动vehicle定位系统（例如，VehiclePositiontimestamp ) 建议生产者尽可能提供这些可选字段。
+*   **必填**：此字段必須由GTFS - 實時飼料生產者。
+*   **有條件要求**：此字段在某些條件下是必需的，在字段*Description*中進行了概述。在這些條件之外，該字段是可選的。
+*   **可選**：該字段是可選的，生產者不需要實現。但是，如果數據在基礎自動vehicle定位系統（例如，VehiclePositiontimestamp ) 建議生產者盡可能提供這些可選字段。
 
-*请注意，语义要求未在*GTFS *-实时版本 1.0，因此提供*gtfs_realtime_version *of `1`可能不满足这些要求（详见[语义要求提案](https://github.com/google/transit/pull/64)）。*
+*請注意，語義要求未在*GTFS *-實時版本 1.0，因此提供*gtfs_realtime_version *of `1`可能不滿足這些要求（詳見[語義要求提案](https://github.com/google/transit/pull/64)）。 *
 
-#### 基数
+#### 基數
 
-*基数*表示可以为特定字段提供的元素数量，具有以下值：
+*基數*表示可以為特定字段提供的元素數量，具有以下值：
 
-* **One** - 可为该字段提供单个 one 元素。这映射到[Protocol Buffer *required*和*optional* cardinalities](https://developers.google.com/protocol-buffers/docs/proto#simple) 。
-* **许多**- 可以为此字段提供许多元素（0、1 或更多）。这映射到[Protocol Buffer 的*重复*基数](https://developers.google.com/protocol-buffers/docs/proto#simple)。
+* **One** - 可為該字段提供單個 one 元素。這映射到[Protocol Buffer *required*和*optional* cardinalities](https://developers.google.com/protocol-buffers/docs/proto#simple) 。
+* **許多**- 可以為此字段提供許多元素（0、1 或更多）。這映射到[Protocol Buffer 的*重複*基數](https://developers.google.com/protocol-buffers/docs/proto#simple)。
 
-始终参考*必填*字段和*说明*字段以查看字段何时为必填、有条件必填或可选。请参考[GTFS](<https://github.com/google/transit/blob/master/\<glossary variable=>) [-实时/原型/](<https://github.com/google/transit/blob/master/\<glossary variable=>)GTFS [-realtime.proto">](<https://github.com/google/transit/blob/master/\<glossary variable=>)GTFS [`GTFS -realtime.proto`](<https://github.com/google/transit/blob/master/\<glossary variable=>)用于协议缓冲区基数。
+始終參考*必填*字段和*說明*字段以查看字段何時為必填、有條件必填或可選。請參考[GTFS](<https://github.com/google/transit/blob/master/\<glossary variable=>) [-實時/原型/](<https://github.com/google/transit/blob/master/\<glossary variable=>)GTFS [-realtime.proto">](<https://github.com/google/transit/blob/master/\<glossary variable=>)GTFS [`GTFS -realtime.proto`](<https://github.com/google/transit/blob/master/\<glossary variable=>)用於協議緩衝區基數。
 
-#### 协议缓冲区数据类型
+#### 協議緩衝區數據類型
 
-以下协议缓冲区数据类型用于描述提要元素：
+以下協議緩衝區數據類型用於描述提要元素：
 
-*   message: 复合型
+*   message: 複合型
 *   enum: 固定值列表
 
-#### 实验领域
+#### 實驗領域
 
-标记为**实验性**的字段可能会发生变化，尚未正式纳入规范。未来可能会正式采用一个**实验**领域。
+標記為**實驗性**的字段可能會發生變化，尚未正式納入規範。未來可能會正式採用一個**實驗**領域。
 
 ## 元素索引
 
@@ -84,208 +84,208 @@ search:
 
 ## message FeedMessage
 
-提要的内容message .每个message 流中的内容是作为对适当 HTTP GET 请求的响应而获得的。实时馈送总是相对于现有的GTFS喂养。所有entityids 相对于GTFS喂养。
+提要的內容message .每個message 流中的內容是作為對適當 HTTP GET 請求的響應而獲得的。實時饋送總是相對於現有的GTFS餵養。所有entityids 相對於GTFS餵養。
 
 **字段**
 
-| _**字段名称**_ | _**类型**_                          | _**必需的**_ | _**基数**_ | _**描述**_                                                                |
+| _**字段名稱**_ | _**類型**_                          | _**必需的**_ | _**基數**_ | _**描述**_                                                                |
 | ---------- | --------------------------------- | --------- | -------- | ----------------------------------------------------------------------- |
-| **header** | [FeedHeader](#message-feedheader) | 必需的       | 一        | 关于此提要和提要的元数据message .                                                    |
-| **entity** | [FeedEntity](#message-feedentity) | 有条件要求     | 许多       | 提要的内容。如果有真-time公交系统可用的信息，必须提供此字段。如果这个字段是EMPTY，消费者应该假设没有真正的-time系统可用的信息。 |
+| **header** | [FeedHeader](#message-feedheader) | 必需的       | 一        | 關於此提要和提要的元數據message .                                                    |
+| **entity** | [FeedEntity](#message-feedentity) | 有條件要求     | 許多       | 提要的內容。如果有真-time公交系統可用的信息，必須提供此字段。如果這個字段是EMPTY，消費者應該假設沒有真正的-time系統可用的信息。 |
 
 
 ## message FeedHeader
 
-有关提要的元数据，包含在提要消息中。
+有關提要的元數據，包含在提要消息中。
 
 **字段**
 
-| _**字段名称**_                | _**类型**_                                                                   | _**必需的**_ | _**基数**_ | _**描述**_                                                                                                                                                                                            |
+| _**字段名稱**_                | _**類型**_                                                                   | _**必需的**_ | _**基數**_ | _**描述**_                                                                                                                                                                                            |
 | ------------------------- | -------------------------------------------------------------------------- | --------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **gtfs_realtime_version** | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 必需的       | 一        | 供稿规范的版本。当前版本是2.0。                                                                                                                                                                                   |
+| **gtfs_realtime_version** | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 必需的       | 一        | 供稿規範的版本。當前版本是2.0。 |
 | **Incrementality**        | [Incrementality](#enum-incrementality)                                     | 必需的       | 一        |                                                                                                                                                                                                     |
-| **timestamp**             | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 必需的       | 一        | 这个timestamp标识创建此提要的内容的时刻（在服务器中time）。在 POSIX 中time（即自 1970 年 1 月 1 日 00:00:00 UTC 以来的秒数）。避免time强烈建议生成和使用实时信息的系统之间的偏差timestamp从一个time服务器。使用 Stratum 3 甚至更低的 Stratum 服务器是完全可以接受的，因为time最多几秒钟的差异是可以容忍的。 |
+| **timestamp**             | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 必需的       | 一        | 這個timestamp標識創建此提要的內容的時刻（在服務器中time）。在 POSIX 中time（即自 1970 年 1 月 1 日 00:00:00 UTC 以來的秒數）。避免time強烈建議生成和使用實時信息的系統之間的偏差timestamp從一個time服務器。使用 Stratum 3 甚至更低的 Stratum 服務器是完全可以接受的，因為time最多幾秒鐘的差異是可以容忍的。 |
 
 ## enum Incrementality
 
-确定当前提取是否是增量的。
+確定當前提取是否是增量的。
 
-*   FULL_DATASET：此提要更新将覆盖提要的所有先前实时信息。因此，本次更新预计将提供一个FULL所有已知实时信息的快照。
-*   DIFFERENTIAL：目前，此模式**不受支持**，并且**未指定**使用此模式的提要的行为。有关于[GTFS](<http://groups.google.com/group/\<glossary variable=>)的讨论[-实时">](<http://groups.google.com/group/\<glossary variable=>)GTFS Realtime围绕完全指定行为的[邮件列表](<http://groups.google.com/group/\<glossary variable=>)DIFFERENTIAL模式和文档将在这些讨论完成后更新。
+*   FULL_DATASET：此提要更新將覆蓋提要的所有先前實時信息。因此，本次更新預計將提供一個FULL所有已知實時信息的快照。
+*   DIFFERENTIAL：目前，此模式**不受支持**，並且**未指定**使用此模式的提要的行為。有關於[GTFS](<http://groups.google.com/group/\<glossary variable=>)的討論[-實時">](<http://groups.google.com/group/\<glossary variable=>)GTFS Realtime圍繞完全指定行為的[郵件列表](<http://groups.google.com/group/\<glossary variable=>)DIFFERENTIAL模式和文檔將在這些討論完成後更新。
 
-**价值观**
+**價值觀**
 
-| _**价值**_         |
+| _**價值**_         |
 | ---------------- |
 | **FULL_DATASET** |
 | **DIFFERENTIAL** |
 
 ## message FeedEntity
 
-定义（或更新）entity在运输提要中。如果entity没有被删除，正好是 'trip_update ', 'vehicle', 'Alert' 和 'Shape' 字段应该被填充。
+定義（或更新）entity在運輸提要中。如果entity沒有被刪除，正好是 'trip_update ', 'vehicle', 'Alert' 和 'Shape' 字段應該被填充。
 
 **字段**
 
-| _**字段名称**_      | _**类型**_                                                                   | _**必需的**_ | _**基数**_ | _**描述**_                                                                                                                                   |
+| _**字段名稱**_      | _**類型**_                                                                   | _**必需的**_ | _**基數**_ | _**描述**_                                                                                                                                   |
 | --------------- | -------------------------------------------------------------------------- | --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| **id**          | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 必需的       | 一        | 供稿唯一标识符entity. id 仅用于提供Incrementality支持。提要引用的实际实体必须由显式选择器指定（请参阅EntitySelector下面了解更多INFO）。                                                  |
-| **is_deleted**  | [bool](https://developers.google.com/protocol-buffers/docs/proto#scalar)   | 可选的       | 一        | 这是否entity将被删除。应该只为带有Incrementality的DIFFERENTIAL- 不应为包含以下内容的提要提供此字段Incrementality的FULL_DATASET.                                             |
-| **trip_update** | [TripUpdate](#message-tripupdate)                                          | 有条件要求     | 一        | 实时数据departure的延误trip.至少其中一个字段trip_update ,vehicle,Alert， 或者Shape必须提供 - 所有这些字段都不能EMPTY.                                                     |
-| **vehicle**     | [VehiclePosition](#message-vehicleposition)                                | 有条件要求     | 一        | 实时数据Position一个vehicle.至少其中一个字段trip_update ,vehicle,Alert， 或者Shape必须提供 - 所有这些字段都不能EMPTY.                                                    |
-| **Alert**       | [Alert](#message-alert)                                                    | 有条件要求     | 一        | 实时数据Alert.至少其中一个字段trip_update ,vehicle,Alert， 或者Shape必须提供 - 所有这些字段都不能EMPTY.                                                                |
-| **Shape**       | [Shape](#message-shape)                                                    | 有条件要求     | 一        | 实时数据ADDED形状，例如对于DETOUR.至少其中一个字段trip_update ,vehicle,Alert， 或者Shape必须提供 - 所有这些字段都不能EMPTY.<br/><br/>**警告：**这个领域仍然**实验**，并且可能会发生变化。将来可能会正式采用。 |
+| **id**          | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 必需的       | 一        | 供稿唯一標識符entity. id 僅用於提供Incrementality支持。提要引用的實際實體必須由顯式選擇器指定（請參閱EntitySelector下面了解更多INFO）。 |
+| **is_deleted**  | [bool](https://developers.google.com/protocol-buffers/docs/proto#scalar)   | 可選的       | 一        | 這是否entity將被刪除。應該只為帶有Incrementality的DIFFERENTIAL- 不應為包含以下內容的提要提供此字段Incrementality的FULL_DATASET.                                             |
+| **trip_update** | [TripUpdate](#message-tripupdate)                                          | 有條件要求     | 一        | 實時數據departure的延誤trip.至少其中一個字段trip_update ,vehicle,Alert， 或者Shape必須提供 - 所有這些字段都不能EMPTY.                                                     |
+| **vehicle**     | [VehiclePosition](#message-vehicleposition)                                | 有條件要求     | 一        | 實時數據Position一個vehicle.至少其中一個字段trip_update ,vehicle,Alert， 或者Shape必須提供 - 所有這些字段都不能EMPTY.                                                    |
+| **Alert**       | [Alert](#message-alert)                                                    | 有條件要求     | 一        | 實時數據Alert.至少其中一個字段trip_update ,vehicle,Alert， 或者Shape必須提供 - 所有這些字段都不能EMPTY.                                                                |
+| **Shape**       | [Shape](#message-shape)                                                    | 有條件要求     | 一        | 實時數據ADDED形狀，例如對於DETOUR.至少其中一個字段trip_update ,vehicle,Alert， 或者Shape必須提供 - 所有這些字段都不能EMPTY.<br/><br/>**警告：**這個領域仍然**實驗**，並且可能會發生變化。將來可能會正式採用。 |
 
 
 ## message TripUpdate
 
-实时更新进度vehicle沿着一个trip.另请参阅[行程](</realtime/\<glossary variable=>)的一般讨论[-更新">](</realtime/\<glossary variable=>)trip[更新实体](</realtime/\<glossary variable=>)。
+實時更新進度vehicle沿著一個trip.另請參閱[行程](</realtime/\<glossary variable=>)的一般討論[-更新">](</realtime/\<glossary variable=>)trip[更新實體](</realtime/\<glossary variable=>)。
 
-取决于价值ScheduleRelationship， 一个TripUpdate可以指定：
+取決於價值ScheduleRelationship， 一個TripUpdate可以指定：
 
-*   一个trip按照时间表进行。
-*   一个trip沿着一条路线前进，但没有固定的时间表。
-*   一个trip那是ADDED或删除关于时间表。
-*   一个新的trip这是现有的副本trip在静态GTFS .它将在服务日期运行，并且time中指定TripProperties .
+*   一個trip按照時間表進行。
+*   一個trip沿著一條路線前進，但沒有固定的時間表。
+*   一個trip那是ADDED或刪除關於時間表。
+*   一個新的trip這是現有的副本trip在靜態GTFS .它將在服務日期運行，並且time中指定TripProperties .
 
-更新可能是未来的，预测的arrival/departure事件，或已经发生的过去事件。在大多数情况下，关于过去事件的信息是一个测量值，因此它uncertainty建议值为 0。尽管可能存在不成立的情况，因此允许具有uncertainty过去事件的值不同于 0。如果有更新uncertainty不是 0，要么更新是一个近似预测trip尚未完成或测量不精确或更新是对过去的预测，在事件发生后尚未得到验证。
+更新可能是未來的，預測的arrival/departure事件，或已經發生的過去事件。在大多數情況下，關於過去事件的信息是一個測量值，因此它uncertainty建議值為 0。儘管可能存在不成立的情況，因此允許具有uncertainty過去事件的值不同於 0。如果有更新uncertainty不是 0，要么更新是一個近似預測trip尚未完成或測量不精確或更新是對過去的預測，在事件發生後尚未得到驗證。
 
-如果一个vehicle正在为同一个街区内的多个行程提供服务（有关行程和街区的更多信息，请参阅GTFStrips.txt ):
+如果一個vehicle正在為同一個街區內的多個行程提供服務（有關行程和街區的更多信息，請參閱GTFStrips.txt ):
 
-*   提要应包括TripUpdate为了trip目前由vehicle.鼓励生产者在当前行程之后包含一次或多次行程的 TripUpdatestrip在这vehicle的块，如果生产者对这些未来的预测质量有信心trip(s)。包括相同的多个 TripUpdatesvehicle避免对骑手的预测“弹出”作为vehicle从一个过渡trip到另一个人，并提前通知乘客影响下游行程的延误（例如，当已知delay超过计划的旅行之间的停留时间）。
-*   各自的TripUpdate实体不需要是ADDED以与它们相同的顺序添加到提要中SCHEDULED在块中。例如，如果存在`trip_ids` 1、2 和 3 的行程都属于一个街区，则vehicle旅行trip1，那么trip2，然后trip3、trip_update实体可以按任何顺序出现 - 例如，添加trip2、那么trip1，然后trip3 是允许的。
+*   提要應包括TripUpdate為了trip目前由vehicle.鼓勵生產者在當前行程之後包含一次或多次行程的 TripUpdatestrip在這vehicle的塊，如果生產者對這些未來的預測質量有信心trip(s)。包括相同的多個 TripUpdatesvehicle避免對騎手的預測“彈出”作為vehicle從一個過渡trip到另一個人，並提前通知乘客影響下游行程的延誤（例如，當已知delay超過計劃的旅行之間的停留時間）。
+*   各自的TripUpdate實體不需要是ADDED以與它們相同的順序添加到提要中SCHEDULED在塊中。例如，如果存在`trip_ids` 1、2 和 3 的行程都屬於一個街區，則vehicle旅行trip1，那麼trip2，然後trip3、trip_update實體可以按任何順序出現 - 例如，添加trip2、那麼trip1，然後trip3 是允許的。
 
-请注意，更新可以描述一个trip已经完成了。到此end, 提供最后一站的更新就足够了trip.如果time的arrival在最后一站是过去，客户会得出结论，整个trip是过去的（尽管无关紧要，也可以为之前的停靠点提供更新）。此选项与trip已提前完成，但按照计划，trip目前仍在进行中time.删除此更新trip可以让客户假设trip仍在进行中。请注意，允许但不是必须的提要提供者清除过去的更新 - 这是实际有用的一种情况。
+請注意，更新可以描述一個trip已經完成了。到此end, 提供最後一站的更新就足夠了trip.如果time的arrival在最後一站是過去，客戶會得出結論，整個trip是過去的（儘管無關緊要，也可以為之前的停靠點提供更新）。此選項與trip已提前完成，但按照計劃，trip目前仍在進行中time.刪除此更新trip可以讓客戶假設trip仍在進行中。請注意，允許但不是必須的提要提供者清除過去的更新 - 這是實際有用的一種情況。
 
 **字段**
 
-| _**字段名称**_           | _**类型**_                                                                   | _**必需的**_ | _**基数**_ | _**描述**_                                                                                                                                                                                                                                                                                                                                        |
+| _**字段名稱**_           | _**類型**_                                                                   | _**必需的**_ | _**基數**_ | _**描述**_|
 | -------------------- | -------------------------------------------------------------------------- | --------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **trip**             | [TripDescriptor](#message-tripdescriptor)                                  | 必需的       | 一        | 这trip这message 适用于。最多可以有一个TripUpdateentity对于每个实际trip实例。如果没有，则意味着没有可用的预测信息。它确实_不是_意味着trip正在按计划进行。                                                                                                                                                                                                                                                  |
-| **vehicle**          | [VehicleDescriptor](#message-vehicledescriptor)                            | 可选的       | 一        | 附加信息vehicle这是服务这个trip.                                                                                                                                                                                                                                                                                                                          |
-| **stop_time_update** | [StopTimeUpdate](#message-stoptimeupdate)                                  | 有条件要求     | 许多       | 对 StopTimes 的更新trip（未来，即预测，在某些情况下，过去的，即已经发生的）。更新必须按stop_sequence，并申请以下所有站点trip直到下一个指定stop_time_update.最后一个stop_time_update必须为trip除非trip.schedule_relationship是CANCELED或者DUPLICATED- 如果trip是CANCELED，不需要提供 stop_time_updates。如果trip是DUPLICATED，可以提供 stop_time_updates 来指示实时time新的信息trip.                                                         |
-| **timestamp**        | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 可选的       | 一        | 最近的时刻vehicle是真的——time测量进度以估计未来的停止时间。当提供过去的 StopTimes 时，arrival/departure次可能早于该值。在 POSIX 中time（即自 1970 年 1 月 1 日 00:00:00 UTC 以来的秒数）。                                                                                                                                                                                                            |
-| **delay**            | [int32](https://developers.google.com/protocol-buffers/docs/proto#scalar)  | 可选的       | 一        | 目前的进度偏差trip.delay仅应在相对于某些现有时间表给出预测时指定GTFS .<br/>delay（以秒为单位）可以是正数（意味着vehicle迟到）或否定（意味着vehicle提前了）。delay为 0 意味着vehicle正好在time.<br/>delayStopTimeUpdates 中的信息优先于trip-等级delay信息，这样trip-等级delay只传播到下一站trip与StopTimeUpdatedelay指定的值。<br/>强烈建议饲料供应商提供TripUpdate.timestamp值指示何时delay最后更新值，以评估数据的新鲜度。<br/><br/>**警告：**这个领域仍然**实验**，并且可能会发生变化。将来可能会正式采用。 |
-| **trip_properties**  | [TripProperties](#message-tripproperties)                                  | 可选的       | 一        | 提供更新的属性trip.<br/><br/>**警告：**这个message 还是**实验**，并且可能会发生变化。将来可能会正式采用。                                                                                                                                                                                                                                                                             |
+| **trip**             | [TripDescriptor](#message-tripdescriptor)                                  | 必需的       | 一        | 這trip這message 適用於。最多可以有一個TripUpdateentity對於每個實際trip實例。如果沒有，則意味著沒有可用的預測信息。它確實_不是_意味著trip正在按計劃進行。 |
+| **vehicle**          | [VehicleDescriptor](#message-vehicledescriptor)                            | 可選的       | 一        | 附加信息vehicle這是服務這個trip.                                                                                                                                                                                                                                                                                                                          |
+| **stop_time_update** | [StopTimeUpdate](#message-stoptimeupdate)                                  | 有條件要求     | 許多       | 對 StopTimes 的更新trip（未來，即預測，在某些情況下，過去的，即已經發生的）。更新必須按stop_sequence，併申請以下所有站點trip直到下一個指定stop_time_update.最後一個stop_time_update必須為trip除非trip.schedule_relationship是CANCELED或者DUPLICATED- 如果trip是CANCELED，不需要提供 stop_time_updates。如果trip是DUPLICATED，可以提供 stop_time_updates 來指示實時time新的信息trip.                                                         |
+| **timestamp**        | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 可選的       | 一        | 最近的時刻vehicle是真的——time測量進度以估計未來的停止時間。當提供過去的 StopTimes 時，arrival/departure次可能早於該值。在 POSIX 中time（即自 1970 年 1 月 1 日 00:00:00 UTC 以來的秒數）。 |
+| **delay**            | [int32](https://developers.google.com/protocol-buffers/docs/proto#scalar)  | 可選的       | 一        | 目前的進度偏差trip.delay僅應在相對於某些現有時間表給出預測時指定GTFS .<br/>delay（以秒為單位）可以是正數（意味著vehicle遲到）或否定（意味著vehicle提前了）。 delay為 0 意味著vehicle正好在time.<br/>delayStopTimeUpdates 中的信息優先於trip-等級delay信息，這樣trip-等級delay只傳播到下一站trip與StopTimeUpdatedelay指定的值。 <br/>強烈建議飼料供應商提供TripUpdate.timestamp值指示何時delay最後更新值，以評估數據的新鮮度。 <br/><br/>**警告：**這個領域仍然**實驗**，並且可能會發生變化。將來可能會正式採用。 |
+| **trip_properties**  | [TripProperties](#message-tripproperties)                                  | 可選的       | 一        | 提供更新的屬性trip.<br/><br/>**警告：**這個message 還是**實驗**，並且可能會發生變化。將來可能會正式採用。 |
 
 ## message StopTimeEvent
 
-单个预测事件的时间信息（arrival或者departure）。时序包括delay和/或估计time， 和uncertainty.
+單個預測事件的時間信息（arrival或者departure）。時序包括delay和/或估計time， 和uncertainty.
 
-*   delay当预测是相对于一些现有的时间表给出时，应该使用GTFS .
-*   time应该给出是否有预测的时间表。如果两者time和delay被指定，time将优先（虽然通常，time, 如果给定一个SCHEDULEDtrip, 应该等于SCHEDULEDtime在GTFS +delay）。
+*   delay當預測是相對於一些現有的時間表給出時，應該使用GTFS .
+*   time應該給出是否有預測的時間表。如果兩者time和delay被指定，time將優先（雖然通常，time, 如果給定一個SCHEDULEDtrip, 應該等於SCHEDULEDtime在GTFS +delay）。
 
-uncertainty同样适用于两者time和delay.这uncertainty粗略指定 true 中的预期误差delay（但请注意，我们尚未定义其精确的统计意义）。这是可能的uncertainty为 0，例如在计算机定时控制下行驶的火车。
+uncertainty同樣適用於兩者time和delay.這uncertainty粗略指定 true 中的預期誤差delay（但請注意，我們尚未定義其精確的統計意義）。這是可能的uncertainty為 0，例如在計算機定時控制下行駛的火車。
 
 
 **字段**
 
-| _**字段名称**_      | _**类型**_                                                                  | _**必需的**_ | _**基数**_ | _**描述**_                                                                                                                      |
+| _**字段名稱**_      | _**類型**_                                                                  | _**必需的**_ | _**基數**_ | _**描述**_                                                                                                                      |
 | --------------- | ------------------------------------------------------------------------- | --------- | -------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| **delay**       | [int32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有条件要求     | 一        | delay（以秒为单位）可以是正数（意味着vehicle迟到）或否定（意味着vehicle提前了）。delay为 0 意味着vehicle正好在time.任何一个delay或者time必须在一个StopTimeEvent- 两个字段都不能EMPTY. |
-| **time**        | [int64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有条件要求     | 一        | 绝对事件time.在 POSIX 中time（即自 1970 年 1 月 1 日 00:00:00 UTC 以来的秒数）。任何一个delay或者time必须在一个StopTimeEvent- 两个字段都不能EMPTY.                 |
-| **uncertainty** | [int32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 可选的       | 一        | 如果uncertainty被省略，它被解释为未知。要指定完全确定的预测，请将其设置为uncertainty为 0。                                                                     |
+| **delay**       | [int32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有條件要求     | 一        | delay（以秒為單位）可以是正數（意味著vehicle遲到）或否定（意味著vehicle提前了）。 delay為 0 意味著vehicle正好在time.任何一個delay或者time必須在一個StopTimeEvent- 兩個字段都不能EMPTY. |
+| **time**        | [int64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有條件要求     | 一        | 絕對事件time.在 POSIX 中time（即自 1970 年 1 月 1 日 00:00:00 UTC 以來的秒數）。任何一個delay或者time必須在一個StopTimeEvent- 兩個字段都不能EMPTY.                 |
+| **uncertainty** | [int32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 可選的       |一        | 如果uncertainty被省略，它被解釋為未知。要指定完全確定的預測，請將其設置為uncertainty為 0。 |
 
 ## message StopTimeUpdate
 
-实时更新arrival和/或departure给定停止的事件trip.另请参阅停止的一般讨论time[消息](<#\<glossary variable=>)中的更新[-tripdescriptor">](<#\<glossary variable=>)TripDescriptor和[旅行](</realtime/\<glossary variable=>)[-更新">](</realtime/\<glossary variable=>)trip[更新实体](</realtime/\<glossary variable=>)文档。
+實時更新arrival和/或departure給定停止的事件trip.另請參閱停止的一般討論time[消息](<#\<glossary variable=>)中的更新[-tripdescriptor">](<#\<glossary variable=>)TripDescriptor和[旅行](</realtime/\<glossary variable=>)[-更新">](</realtime/\<glossary variable=>)trip[更新實體](</realtime/\<glossary variable=>)文檔。
 
-可以为过去和未来的事件提供更新。尽管不是必需的，但允许生产者删除过去的事件。更新链接到特定的停止，或者通过stop_sequence或者stop_id ，因此必须设置这些字段之一。如果一样stop_id在一次访问中不止一次trip， 然后stop_sequence应在所有 StopTimeUpdates 中为此提供stop_id在那trip.
+可以為過去和未來的事件提供更新。儘管不是必需的，但允許生產者刪除過去的事件。更新鏈接到特定的停止，或者通過stop_sequence或者stop_id ，因此必須設置這些字段之一。如果一樣stop_id在一次訪問中不止一次trip， 然後stop_sequence應在所有 StopTimeUpdates 中為此提供stop_id在那trip.
 
 
 **字段**
 
-| _**字段名称**_                     | _**类型**_                                                                   | _**必需的**_ | _**基数**_ | _**描述**_                                                                                                                                                                                                                                                   |
+| _**字段名稱**_                     | _**類型**_                                                                   | _**必需的**_ | _**基數**_ | _**描述**_                                                                                                                                                                                                                                                   |
 | ------------------------------ | -------------------------------------------------------------------------- | --------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **stop_sequence**              | [uint32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有条件要求     | 一        | 必须与中相同stop_times.txt在相应的GTFS喂养。任何一个stop_sequence或者stop_id必须在一个StopTimeUpdate- 两个字段都不能EMPTY.stop_sequence访问相同的旅行需要stop_id不止一次（例如，一个循环）来消除预测是针对哪个停止的歧义。如果`StopTimeProperties.assigned_stop_id`被填充，那么`stop_sequence`必须填充。                                     |
-| **stop_id**                    | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有条件要求     | 一        | 必须与中相同stops.txt在相应的GTFS喂养。任何一个stop_sequence或者stop_id必须在一个StopTimeUpdate- 两个字段都不能EMPTY.如果`StopTimeProperties.assigned_stop_id`已填充，最好省略`stop_id`并且只使用`stop_sequence`.如果`StopTimeProperties.assigned_stop_id`和`stop_id`人口稠密，`stop_id`必须匹配`assigned_stop_id` . |
-| **arrival**                    | [StopTimeEvent](#message-stoptimeevent)                                    | 有条件要求     | 一        | 如果schedule_relationship是EMPTY或者SCHEDULED， 任何一个arrival或者departure必须在一个StopTimeUpdate- 两个字段都不能EMPTY.arrival和departure可能两者都是EMPTY什么时候schedule_relationship是SKIPPED.如果schedule_relationship是 NO_DATA，arrival和departure一定是EMPTY.                                |
-| **departure**                  | [StopTimeEvent](#message-stoptimeevent)                                    | 有条件要求     | 一        | 如果schedule_relationship是EMPTY或者SCHEDULED， 任何一个arrival或者departure必须在一个StopTimeUpdate- 两个字段都不能EMPTY.arrival和departure可能两者都是EMPTY什么时候schedule_relationship是SKIPPED.如果schedule_relationship是 NO_DATA，arrival和departure一定是EMPTY.                                |
-| **departure_occupancy_status** | [OccupancyStatus](#enum-occupancystatus)                                   | 可选的       | 一        | 预计客座率vehicle之后立马departure从给定的停止。如果提供，stop_sequence必须提供。提供departure_occupancy_status不提供任何真实的timearrival或者departure预测，填充此字段并设置StopTimeUpdate.schedule_relationship = NO_DATA。<br/><br/>**警告：**这个领域仍然**实验**，并且可能会发生变化。将来可能会正式采用。                              |
-| **schedule_relationship**      | [ScheduleRelationship](#enum-schedulerelationship)                         | 可选的       | 一        | 默认关系是SCHEDULED.                                                                                                                                                                                                                                            |
-| **stop_time_properties**       | [StopTimeProperties](#message-stoptimeproperties)                          | 可选的       | 一        | 内定义的某些属性的实时更新GTFSstop_times.txt<br/><br/>**警告：**这个领域仍然**实验**，并且可能会发生变化。将来可能会正式采用。                                                                                                                                                                          |
+| **stop_sequence**              | [uint32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有條件要求     | 一        | 必須與中相同stop_times.txt在相應的GTFS餵養。任何一個stop_sequence或者stop_id必須在一個StopTimeUpdate- 兩個字段都不能EMPTY.stop_sequence訪問相同的旅行需要stop_id不止一次（例如，一個循環）來消除預測是針對哪個停止的歧義。如果`StopTimeProperties.assigned_stop_id`被填充，那麼`stop_sequence`必須填充。 |
+| **stop_id**                    | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有條件要求     | 一        | 必須與中相同stops.txt在相應的GTFS餵養。任何一個stop_sequence或者stop_id必須在一個StopTimeUpdate- 兩個字段都不能EMPTY.如果`StopTimeProperties.assigned_stop_id`已填充，最好省略`stop_id`並且只使用`stop_sequence`.如果`StopTimeProperties.assigned_stop_id`和`stop_id`人口稠密，`stop_id`必須匹配`assigned_stop_id` . |
+| **arrival**                    | [StopTimeEvent](#message-stoptimeevent)                                    | 有條件要求     | 一        | 如果schedule_relationship是EMPTY或者SCHEDULED， 任何一個arrival或者departure必須在一個StopTimeUpdate- 兩個字段都不能EMPTY.arrival和departure可能兩者都是EMPTY什麼時候schedule_relationship是SKIPPED.如果schedule_relationship是 NO_DATA，arrival和departure一定是EMPTY.                                |
+| **departure**                  | [StopTimeEvent](#message-stoptimeevent)                                    | 有條件要求     | 一        | 如果schedule_relationship是EMPTY或者SCHEDULED， 任何一個arrival或者departure必須在一個StopTimeUpdate- 兩個字段都不能EMPTY.arrival和departure可能兩者都是EMPTY什麼時候schedule_relationship是SKIPPED.如果schedule_relationship是 NO_DATA，arrival和departure一定是EMPTY.                                |
+| **departure_occupancy_status** | [OccupancyStatus](#enum-occupancystatus)                                   | 可選的       | 一        | 預計客座率vehicle之後立馬departure從給定的停止。如果提供，stop_sequence必須提供。提供departure_occupancy_status不提供任何真實的timearrival或者departure預測，填充此字段並設置StopTimeUpdate.schedule_relationship = NO_DATA。 <br/><br/>**警告：**這個領域仍然**實驗**，並且可能會發生變化。將來可能會正式採用。 |
+| **schedule_relationship**      | [ScheduleRelationship](#enum-schedulerelationship)                         | 可選的       | 一        | 默認關係是SCHEDULED.                                                                                                                                                                                                                                            |
+| **stop_time_properties**       | [StopTimeProperties](#message-stoptimeproperties)                          | 可選的       | 一        | 內定義的某些屬性的實時更新GTFSstop_times.txt<br/><br/>**警告：**這個領域仍然**實驗**，並且可能會發生變化。將來可能會正式採用。 |
 
 
 ## enum ScheduleRelationship
 
-此 StopTime 与静态计划之间的关系。
+此 StopTime 與靜態計劃之間的關係。
 
-**价值观**
+**價值觀**
 
-| _**价值**_        | _**评论**_                                                                                                                                                                                                                                                                                                                                             |
+| _**價值**_        | _**評論**_                                                                                                                                                                                                                                                                                                                                             |
 | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **SCHEDULED**   | 这vehicle正在按照其静态的停靠时间表进行，尽管不一定按照时间表的时间。这是**默认**行为。至少其中之一arrival和departure必须提供。基于频率的旅行（GTFSfrequencies.txt与exact_times = 0) 不应该有SCHEDULED值并应该使用UNSCHEDULED反而。                                                                                                                                                                                          |
-| **SKIPPED**     | 停靠点是SKIPPED，即vehicle不会停在这一站。arrival和departure是可选的。设置时`SKIPPED`不会传播到相同的后续站点trip（即，vehicle将在随后的站点停止trip除非这些站点也有`stop_time_update`和`schedule_relationship: SKIPPED`）。delay从上一站trip_做_传播到`SKIPPED`停止。换句话说，如果一个`stop_time_update`带着`arrival`或者`departure`预测未设置为停止后`SKIPPED`停止，上游的预测`SKIPPED`停止后将传播到停止`SKIPPED`停止和随后的停止trip直到一个`stop_time_update`为随后的停止提供。 |
-| **没有数据**        | 没有给出此站点的数据。它表示没有可用的实时时间信息。当设置 NO_DATA 通过后续停靠点传播时，因此这是指定您没有实时时间信息的停靠点的推荐方式。当 NO_DATA 均未设置时arrival也不departure应提供。                                                                                                                                                                                                                                      |
-| **UNSCHEDULED** | 这vehicle正在运行基于频率的trip(GTFSfrequencies.txt精确时间 = 0)。此值不应用于未定义的行程GTFSfrequencies.txt , 或旅行GTFSfrequencies.txt精确时间 = 1。行程包含`stop_time_updates`和`schedule_relationship: UNSCHEDULED`还必须设置TripDescriptor`schedule_relationship: UNSCHEDULED` <br/><br/>**警告：**这个领域仍然**实验**，并且可能会发生变化。将来可能会正式采用。                                                           |
+| **SCHEDULED**   | 這vehicle正在按照其靜態的停靠時間表進行，儘管不一定按照時間表的時間。這是**默認**行為。至少其中之一arrival和departure必須提供。基於頻率的旅行（GTFSfrequencies.txt與exact_times = 0) 不應該有SCHEDULED值並應該使用UNSCHEDULED反而。 |
+| **SKIPPED**     | 停靠點是SKIPPED，即vehicle不會停在這一站。 arrival和departure是可選的。設置時`SKIPPED`不會傳播到相同的後續站點trip（即，vehicle將在隨後的站點停止trip除非這些站點也有`stop_time_update`和`schedule_relationship: SKIPPED`）。 delay從上一站trip_做_傳播到`SKIPPED`停止。換句話說，如果一個`stop_time_update`帶著`arrival`或者`departure`預測未設置為停止後`SKIPPED`停止，上游的預測`SKIPPED`停止後將傳播到停止`SKIPPED`停止和隨後的停止trip直到一個`stop_time_update`為隨後的停止提供。 |
+| **沒有數據**        | 沒有給出此站點的數據。它表示沒有可用的實時時間信息。當設置 NO_DATA 通過後續停靠點傳播時，因此這是指定您沒有實時時間信息的停靠點的推薦方式。當 NO_DATA 均未設置時arrival也不departure應提供。 |
+| **UNSCHEDULED** | 這vehicle正在運行基於頻率的trip(GTFSfrequencies.txt精確時間 = 0)。此值不應用於未定義的行程GTFSfrequencies.txt , 或旅行GTFSfrequencies.txt精確時間 = 1。行程包含`stop_time_updates`和`schedule_relationship: UNSCHEDULED`還必須設置TripDescriptor`schedule_relationship: UNSCHEDULED` <br/><br/>**警告：**這個領域仍然**實驗**，並且可能會發生變化。將來可能會正式採用。 |
 
 
 ## message StopTimeProperties
 
-中定义的某些属性的实时更新GTFSstop_times.txt .
+中定義的某些屬性的實時更新GTFSstop_times.txt .
 
-**注意：**这个message 仍处于**试验阶段**，可能会发生变化。将来可能会正式采用。<br/>
+**注意：**這個message 仍處於**試驗階段**，可能會發生變化。將來可能會正式採用。 <br/>
 
 **字段**
 
-| _**字段名称**_           | _**类型**_                                                                   | _**必需的**_ | _**基数**_ | _**描述**_                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| _**字段名稱**_           | _**類型**_                                                                   | _**必需的**_ | _**基數**_ | _**描述**_                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | -------------------- | -------------------------------------------------------------------------- | --------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **assigned_stop_id** | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 可选的       | 一        | 支持实time停止分配。指一个`stop_id`中定义的GTFS`stops.txt` .<br/>新的`assigned_stop_id`不应导致显着不同trip的经验end用户比`stop_id`定义在GTFS`stop_times.txt` .换句话说，end用户不应查看此新内容`stop_id`如果新站点在没有任何附加上下文的应用程序中呈现，则视为“不寻常的变化”。例如，此字段旨在通过使用`stop_id`与最初定义的停靠点属于同一站GTFS`stop_times.txt` .<br/>在不提供任何真实信息的情况下分配止损timearrival或者departure预测，填充此字段并设置`StopTimeUpdate.schedule_relationship = NO_DATA` .<br/>如果填写此字段，`StopTimeUpdate.stop_sequence`必须填充和`StopTimeUpdate.stop_id`不应填充。停止分配应反映在其他GTFS - 实时字段（例如，`VehiclePosition.stop_id`）。<br/><br/>**警告：**这个领域仍然**实验**，并且可能会发生变化。将来可能会正式采用。 |
+| **assigned_stop_id** | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 可選的       | 一        | 支持實time停止分配。指一個`stop_id`中定義的GTFS`stops.txt` .<br/>新的`assigned_stop_id`不應導致顯著不同trip的經驗end用戶比`stop_id`定義在GTFS`stop_times.txt` .換句話說，end用戶不應查看此新內容`stop_id`如果新站點在沒有任何附加上下文的應用程序中呈現，則視為“不尋常的變化”。例如，此字段旨在通過使用`stop_id`與最初定義的停靠點屬於同一站GTFS`stop_times.txt` .<br/>在不提供任何真實信息的情況下分配止損timearrival或者departure預測，填充此字段並設置`StopTimeUpdate.schedule_relationship = NO_DATA` .<br/>如果填寫此字段，`StopTimeUpdate.stop_sequence`必須填充和`StopTimeUpdate.stop_id`不應填充。停止分配應反映在其他GTFS - 實時字段（例如，`VehiclePosition.stop_id`）。 <br/><br/>**警告：**這個領域仍然**實驗**，並且可能會發生變化。將來可能會正式採用。 |
 
 ## message TripProperties
 
-定义更新的属性trip
+定義更新的屬性trip
 
-**注意：**这个message 仍处于**试验阶段**，可能会发生变化。将来可能会正式采用。<br/>.<br/>
+**注意：**這個message 仍處於**試驗階段**，可能會發生變化。將來可能會正式採用。 <br/>.<br/>
 
 
 **字段**
 
-| _**字段名称**_     | _**类型**_                                                                   | _**必需的**_ | _**基数**_ | _**描述**_                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| _**字段名稱**_     | _**類型**_                                                                   | _**必需的**_ | _**基數**_ | _**描述**_                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | -------------- | -------------------------------------------------------------------------- | --------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **trip_id**    | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有条件要求     | 一        | 定义一个新的标识符trip这是现有的副本trip在 (CSV) 中定义GTFStrips.txt但会start在不同的服务日期和/或time（定义使用`TripProperties.start_date`和`TripProperties.start_time`）。见定义`trips.trip_id`在 (CSV)GTFS .它的值必须不同于 (CSV) 中使用的值GTFS .此字段是必需的，如果`schedule_relationship`是`DUPLICATED` , 否则这个字段不能被填充并且会被消费者忽略。<br/><br/>**警告：**这个领域仍然**实验**，并且可能会发生变化。将来可能会正式采用。                                                                                                                                                                                                                                                                                                                                                                          |
-| **start_date** | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有条件要求     | 一        | 服务日期DUPLICATEDtrip将运行。必须以 YYYYMMDD 格式提供。此字段是必需的，如果`schedule_relationship`是`DUPLICATED` , 否则这个字段不能被填充并且会被消费者忽略。<br/><br/>**警告：**这个领域仍然**实验**，并且可能会发生变化。将来可能会正式采用。                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| **start_time** | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有条件要求     | 一        | 定义departurestarttime的trip什么时候DUPLICATED.见定义`stop_times.departure_time`在 (CSV)GTFS .SCHEDULEDarrival和departure次为DUPLICATEDtrip是根据原始之间的偏移量计算的trip`departure_time`和这个领域。例如，如果一个GTFStrip有一个停止 A`departure_time`的`10:00:00`并停止 B`departure_time`的`10:01:00` ，并且该字段的值填充为`10:30:00`, 停止 BDUPLICATEDtrip会有一个SCHEDULED`departure_time`的`10:31:00`.真实的-time预言`delay`值应用于此计算的计划time确定预测的time.例如，如果一个departure`delay`的`30`为停止 B 提供，则预测departuretime是`10:31:30`.真实的-time预言`time`值没有应用任何偏移量并指示预测的time如提供。例如，如果一个departure`time`为停止 B 提供代表 10:31:30 的时间，则预测departuretime是`10:31:30`. 此字段是必需的，如果`schedule_relationship`是`DUPLICATED` , 否则这个字段不能被填充并且会被消费者忽略。<br/><br/>**警告：**这个领域仍然**实验**，并且可能会发生变化。将来可能会正式采用。 |
-| **shape_id**   | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 可选的       | 一        | 指定Shape的vehicle为此的旅行路线trip当它与原来的不同时。指一个Shape在 (CSV) 中定义GTFS或新的Shapeentity在一个真实的-time喂养。见定义`trips.shape_id`在 (CSV)GTFS .<br/><br/>**警告：**这个领域仍然**实验**，并且可能会发生变化。将来可能会正式采用。                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| **trip_id**    | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有條件要求     | 一        | 定義一個新的標識符trip這是現有的副本trip在 (CSV) 中定義GTFStrips.txt但會start在不同的服務日期和/或time（定義使用`TripProperties.start_date`和`TripProperties.start_time`）。見定義`trips.trip_id`在 (CSV)GTFS .它的值必須不同於 (CSV) 中使用的值GTFS .此字段是必需的，如果`schedule_relationship`是`DUPLICATED` , 否則這個字段不能被填充並且會被消費者忽略。 <br/><br/>**警告：**這個領域仍然**實驗**，並且可能會發生變化。將來可能會正式採用。 |
+| **start_date** | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有條件要求     | 一        | 服務日期DUPLICATEDtrip將運行。必須以 YYYYMMDD 格式提供。此字段是必需的，如果`schedule_relationship`是`DUPLICATED` , 否則這個字段不能被填充並且會被消費者忽略。 <br/><br/>**警告：**這個領域仍然**實驗**，並且可能會發生變化。將來可能會正式採用。 |
+| **start_time** | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有條件要求     | 一        | 定義departurestarttime的trip什麼時候DUPLICATED.見定義`stop_times.departure_time`在 (CSV)GTFS .SCHEDULEDarrival和departure次為DUPLICATEDtrip是根據原始之間的偏移量計算的trip`departure_time`和這個領域。例如，如果一個GTFStrip有一個停止 A`departure_time`的`10:00:00`並停止 B`departure_time`的`10:01:00` ，並且該字段的值填充為`10:30:00`, 停止 BDUPLICATEDtrip會有一個SCHEDULED`departure_time`的`10:31:00`.真實的-time預言`delay`值應用於此計算的計劃time確定預測的time.例如，如果一個departure`delay`的`30`為停止 B 提供，則預測departuretime是`10:31:30`.真實的-time預言`time`值沒有應用任何偏移量並指示預測的time如提供。例如，如果一個departure`time`為停止 B 提供代表 10:31:30 的時間，則預測departuretime是`10:31:30`. 此字段是必需的，如果`schedule_relationship`是`DUPLICATED` , 否則這個字段不能被填充並且會被消費者忽略。 <br/><br/>**警告：**這個領域仍然**實驗**，並且可能會發生變化。將來可能會正式採用。 |
+| **shape_id**   | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 可選的       | 一        | 指定Shape的vehicle為此的旅行路線trip當它與原來的不同時。指一個Shape在 (CSV) 中定義GTFS或新的Shapeentity在一個真實的-time餵養。見定義`trips.shape_id`在 (CSV)GTFS .<br/><br/>**警告：**這個領域仍然**實驗**，並且可能會發生變化。將來可能會正式採用。 |
 
 
 ## message VehiclePosition
 
-给定的实时定位信息vehicle.
+給定的實時定位信息vehicle.
 
 **字段**
 
-| _**字段名称**_                 | _**类型**_                                                                   | _**必需的**_ | _**基数**_ | _**描述**_                                                                                                                                                                                                                                                                                      |
+| _**字段名稱**_                 | _**類型**_                                                                   | _**必需的**_ | _**基數**_ | _**描述**_                                                                                                                                                                                                                                                                                      |
 | -------------------------- | -------------------------------------------------------------------------- | --------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **trip**                   | [TripDescriptor](#message-tripdescriptor)                                  | 可选的       | 一        | 这trip这vehicle正在服务。可EMPTY或部分，如果vehicle无法识别给定的trip实例。                                                                                                                                                                                                                                           |
-| **vehicle**                | [VehicleDescriptor](#message-vehicledescriptor)                            | 可选的       | 一        | 附加信息vehicle这是服务这个trip.每个条目应该有一个**独特的**vehicleid .                                                                                                                                                                                                                                             |
-| **Position**               | [Position](#message-position)                                              | 可选的       | 一        | 当前的Position这个的vehicle.                                                                                                                                                                                                                                                                        |
-| **current_stop_sequence**  | [uint32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 可选的       | 一        | 当前停靠点的停靠顺序索引。的意思current_stop_sequence （即它所指的止损点）由下式确定current_status.如果current_status不见了IN_TRANSIT_TO假设。                                                                                                                                                                                       |
-| **stop_id**                | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 可选的       | 一        | 标识当前停靠点。该值必须与stops.txt在相应的GTFS喂养。如果`StopTimeProperties.assigned_stop_id`用于分配一个`stop_id`，这个字段也应该反映`stop_id` .                                                                                                                                                                                  |
-| **current_status**         | [VehicleStopStatus](#enum-vehiclestopstatus)                               | 可选的       | 一        | 的确切状态vehicle相对于当前停止。忽略如果current_stop_sequence不见了。                                                                                                                                                                                                                                             |
-| **timestamp**              | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 可选的       | 一        | 时刻vehicle的Position被测量了。在 POSIX 中time（即自 1970 年 1 月 1 日 00:00:00 UTC 以来的秒数）。                                                                                                                                                                                                                   |
-| **congestion_level**       | [CongestionLevel](#enum-congestionlevel)                                   | 可选的       | 一        |                                                                                                                                                                                                                                                                                               |
-| **occupancy_status**       | [OccupancyStatus](#enum-occupancystatus)                                   | _可选的_     | 一        | 客运量状况vehicle或马车。如果multi_carriage_details填充了每个车厢OccupancyStatus, 那么这个字段应该描述整个vehicle考虑所有接受乘客的车厢。<br/><br/>**警告：**这个领域仍然**实验**，并且可能会发生变化。将来可能会正式采用。                                                                                                                                             |
-| **occupancy_percentage**   | [uint32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 可选的       | 一        | 一个百分比值，表示乘客的占用程度vehicle.值 100 应代表总最大占用率vehicle设计用于，包括座位和站立容量，以及当前的操作法规允许。如果乘客数量超过最大设计容量，该值可能会超过 100。精度occupancy_percentage应该足够低，以至于无法跟踪个别乘客的上下车vehicle.如果multi_carriage_details填充了每个车厢occupancy_percentage, 那么这个字段应该描述整个vehicle考虑所有接受乘客的车厢。<br/><br/>**警告：**这个领域仍然**实验**，并且可能会发生变化。将来可能会正式采用。 |
-| **multi_carriage_details** | [CarriageDetails](#message-CarriageDetails)                                | 可选的       | 许多       | 这个给定的多个车厢的详细信息vehicle.第一次出现代表第一个车厢vehicle,**给定当前的行进方向**.的出现次数multi_carriage_details字段表示的车厢数量vehicle.它还包括不可登机的车厢，如发动机，MAINTENANCE车厢等……因为它们为乘客提供了有关站在平台上何处的宝贵信息。<br/><br/>**警告：**这个领域仍然**实验**，并且可能会发生变化。将来可能会正式采用。                                                                              |
+| **trip**                   | [TripDescriptor](#message-tripdescriptor)                                  | 可選的       | 一        | 這trip這vehicle正在服務。可EMPTY或部分，如果vehicle無法識別給定的trip實例。 |
+| **vehicle**                | [VehicleDescriptor](#message-vehicledescriptor)                            | 可選的       | 一        | 附加信息vehicle這是服務這個trip.每個條目應該有一個**獨特的**vehicleid .|
+| **Position**               | [Position](#message-position)                                              | 可選的       | 一        | 當前的Position這個的vehicle.                                                                                                                                                                                                                                                                        |
+| **current_stop_sequence**  | [uint32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 可選的       | 一        | 當前停靠點的停靠順序索引。的意思current_stop_sequence （即它所指的止損點）由下式確定current_status.如果current_status不見了IN_TRANSIT_TO假設。 |
+| **stop_id**                | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 可選的       | 一        | 標識當前停靠點。該值必須與stops.txt在相應的GTFS餵養。如果`StopTimeProperties.assigned_stop_id`用於分配一個`stop_id`，這個字段也應該反映`stop_id` .                                                                                                                                                                                  |
+| **current_status**         | [VehicleStopStatus](#enum-vehiclestopstatus)                               | 可選的       | 一        | 的確切狀態vehicle相對於當前停止。忽略如果current_stop_sequence不見了。 |
+| **timestamp**              | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 可選的       | 一        | 時刻vehicle的Position被測量了。在 POSIX 中time（即自 1970 年 1 月 1 日 00:00:00 UTC 以來的秒數）。 |
+| **congestion_level**       | [CongestionLevel](#enum-congestionlevel)                                   | 可選的       | 一        |                                                                                                                                                                                                                                                                                               |
+| **occupancy_status**       | [OccupancyStatus](#enum-occupancystatus)                                   | _可選的_     | 一        | 客運量狀況vehicle或馬車。如果multi_carriage_details填充了每個車廂OccupancyStatus, 那麼這個字段應該描述整個vehicle考慮所有接受乘客的車廂。 <br/><br/>**警告：**這個領域仍然**實驗**，並且可能會發生變化。將來可能會正式採用。 |
+| **occupancy_percentage**   | [uint32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 可選的       | 一        | 一個百分比值，表示乘客的佔用程度vehicle.值 100 應代表總最大佔用率vehicle設計用於，包括座位和站立容量，以及當前的操作法規允許。如果乘客數量超過最大設計容量，該值可能會超過 100。精度occupancy_percentage應該足夠低，以至於無法跟踪個別乘客的上下車vehicle.如果multi_carriage_details填充了每個車廂occupancy_percentage, 那麼這個字段應該描述整個vehicle考慮所有接受乘客的車廂。 <br/><br/>**警告：**這個領域仍然**實驗**，並且可能會發生變化。將來可能會正式採用。 |
+| **multi_carriage_details** | [CarriageDetails](#message-CarriageDetails)                                | 可選的       | 許多       | 這個給定的多個車廂的詳細信息vehicle.第一次出現代表第一個車廂vehicle,**給定當前的行進方向**.的出現次數multi_carriage_details字段表示的車廂數量vehicle.它還包括不可登機的車廂，如發動機，MAINTENANCE車廂等……因為它們為乘客提供了有關站在平台上何處的寶貴信息。 <br/><br/>**警告：**這個領域仍然**實驗**，並且可能會發生變化。將來可能會正式採用。 |
 
 
 ## enum VehicleStopStatus
 
-**价值观**
+**價值觀**
 
-| _**价值**_          | _**评论**_                                |
+| _**價值**_          | _**評論**_                                |
 | ----------------- | --------------------------------------- |
-| **INCOMING_AT**   | 这vehicle即将到达停靠点（在停靠点显示上，vehicle符号通常闪烁）。 |
-| **STOPPED_AT**    | 这vehicle站在车站。                           |
-| **IN_TRANSIT_TO** | 这vehicle已离开上一站并处于运输途中。                  |
+| **INCOMING_AT**   | 這vehicle即將到達停靠點（在停靠點顯示上，vehicle符號通常閃爍）。 |
+| **STOPPED_AT**    | 這vehicle站在車站。 |
+| **IN_TRANSIT_TO** | 這vehicle已離開上一站並處於運輸途中。 |
 
 ## enum CongestionLevel
 
-CONGESTION影响这一点的水平vehicle.
+CONGESTION影響這一點的水平vehicle.
 
-**价值观**
+**價值觀**
 
-| _**价值**_                     |
+| _**價值**_                     |
 | ---------------------------- |
 | **UNKNOWN_CONGESTION_LEVEL** |
 | **RUNNING_SMOOTHLY**         |
@@ -295,77 +295,77 @@ CONGESTION影响这一点的水平vehicle.
 
 ## enum OccupancyStatus
 
-客运量状况vehicle或马车。
+客運量狀況vehicle或馬車。
 
-个别制作人不得全部发布OccupancyStatus价值观。因此，消费者不能假设OccupancyStatus值遵循线性比例。消费者应代表OccupancyStatus值作为生产商指示和预期的状态。同样，生产者必须使用OccupancyStatus对应于实际的值vehicle占用状态。
+個別製作人不得全部發布OccupancyStatus價值觀。因此，消費者不能假設OccupancyStatus值遵循線性比例。消費者應代表OccupancyStatus值作為生產商指示和預期的狀態。同樣，生產者必須使用OccupancyStatus對應於實際的值vehicle佔用狀態。
 
-有关以线性比例描述乘客占用率的信息，请参阅occupancy_percentage .
+有關以線性比例描述乘客佔用率的信息，請參閱occupancy_percentage .
 
 
-**注意：**此字段仍处于**试验阶段**，可能会发生变化。将来可能会正式采用。
+**注意：**此字段仍處於**試驗階段**，可能會發生變化。將來可能會正式採用。
 
-_**价值观**_
+_**價值觀**_
 
-| _**价值**_                         | _**评论**_                                                   |
+| _**價值**_                         | _**評論**_                                                   |
 | -------------------------------- | ---------------------------------------------------------- |
-| _**EMPTY**_                      | _这vehicle被认为EMPTY大多数情况下，机上乘客很少或没有乘客，但仍在接受乘客。_              |
-| _**MANY_SEATS_AVAILABLE**_       | _这vehicle或车厢有大量可用座位。在可用的总座位中被认为足够大以属于该类别的空闲座位的数量由生产者自行决定。_ |
-| _**FEW_SEATS_AVAILABLE**_        | _这vehicle或车厢有少量可用座位。可被视为小到足以落入这一类别的总座位中的空闲座位数量由生产者自行决定。_   |
-| _**STANDING_ROOM_ONLY**_         | _这vehicle或车厢目前只能容纳站立的乘客。_                                  |
-| _**CRUSHED_STANDING_ROOM_ONLY**_ | _这vehicle或车厢目前只能容纳站立的乘客，并且空间有限。_                           |
-| _**FULL**_                       | _这vehicle被认为FULL通过大多数措施，但可能仍允许乘客登机。_                       |
-| _**NOT_ACCEPTING_PASSENGERS**_   | _这vehicle或运输不接受乘客。这vehicle或车厢通常接受乘客登机。_                    |
-| _**NO_DATA_AVAILABLE**_          | _这vehicle或运输没有任何可用的占用数据time._                              |
-| _**NOT_BOARDABLE**_              | _这vehicle或运输不可登机，从不接受乘客。适用于特殊车辆或车厢（发动机、MAINTENANCE马车等……）。_ |
+| _**EMPTY**_                      | _這vehicle被認為EMPTY大多數情況下，機上乘客很少或沒有乘客，但仍在接受乘客。 _              |
+| _**MANY_SEATS_AVAILABLE**_       | _這vehicle或車廂有大量可用座位。在可用的總座位中被認為足夠大以屬於該類別的空閒座位的數量由生產者自行決定。 _ |
+| _**FEW_SEATS_AVAILABLE**_        | _這vehicle或車廂有少量可用座位。可被視為小到足以落入這一類別的總座位中的空閒座位數量由生產者自行決定。 _   |
+| _**STANDING_ROOM_ONLY**_         | _這vehicle或車廂目前只能容納站立的乘客。 _                                  |
+| _**CRUSHED_STANDING_ROOM_ONLY**_ | _這vehicle或車廂目前只能容納站立的乘客，並且空間有限。 _                           |
+| _**FULL**_                       | _這vehicle被認為FULL通過大多數措施，但可能仍允許乘客登機。 _                       |
+| _**NOT_ACCEPTING_PASSENGERS**_   | _這vehicle或運輸不接受乘客。這vehicle或車廂通常接受乘客登機。 _                    |
+| _**NO_DATA_AVAILABLE**_          | _這vehicle或運輸沒有任何可用的佔用數據time._                              |
+| _**NOT_BOARDABLE**_              | _這vehicle或運輸不可登機，從不接受乘客。適用於特殊車輛或車廂（發動機、MAINTENANCE馬車等……）。 _ |
 
 
 ## message CarriageDetails
 
-车厢特定细节，用于由多个车厢组成的车辆。
+車廂特定細節，用於由多個車廂組成的車輛。
 
-**注意：**这个message 仍处于**试验阶段**，可能会发生变化。将来可能会正式采用。
+**注意：**這個message 仍處於**試驗階段**，可能會發生變化。將來可能會正式採用。
 
 **字段**
 
-| _**字段名称**_               | _**类型**_                                                                   | _**必需的**_ | _**基数**_ | _**描述**_                                                                                                                                                                                                                                                                                                    |
+| _**字段名稱**_               | _**類型**_                                                                   | _**必需的**_ | _**基數**_ | _**描述**_                                                                                                                                                                                                                                                                                                    |
 | ------------------------ | -------------------------------------------------------------------------- | --------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **id**                   | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 可选的       | 一        | 车厢的识别。每个应该是唯一的vehicle.<br/><br/>**警告：**这个领域仍然**实验**，并且可能会发生变化。将来可能会正式采用。                                                                                                                                                                                                                                    |
-| **label**                | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 可选的       | 一        | 用户可见label可能会显示给乘客以帮助识别车厢。示例：“7712”、“汽车 ABC-32”等...<br/>**警告：**这个领域仍然**实验**，并且可能会发生变化。将来可能会正式采用。                                                                                                                                                                                                             |
-| **occupancy_status**     | [OccupancyStatus](#enum-occupancystatus)                                   | 可选的       | 一        | 此给定车厢的占用状态，在此vehicle.默认设置为`NO_DATA_AVAILABLE` .<br/><br/>**警告：**这个领域仍然**实验**，并且可能会发生变化。将来可能会正式采用。                                                                                                                                                                                                           |
-| **occupancy_percentage** | [int32](https://developers.google.com/protocol-buffers/docs/proto#scalar)  | 可选的       | 一        | 这个给定车厢的占用百分比，在这个vehicle.遵循与“VehiclePosition.occupancy_percentage”相同的规则。如果该给定托架的数据不可用，请使用 -1。<br/><br/>**警告：**这个领域仍然**实验**，并且可能会发生变化。将来可能会正式采用。                                                                                                                                                              |
-| **carriage_sequence**    | [uint32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 必需的       | 一        | 识别该车厢相对于其他车厢的顺序vehicle的 CarriageStatus 列表。行进方向上的第一个托架的值必须为 1。第二个值对应于行进方向上的第二个托架，值必须为 2，依此类推。例如，行驶方向的第一节车厢的值为 1。如果行驶方向的第二节车厢的值为 3，则消费者将丢弃所有车厢的数据（即multi_carriage_details场地）。没有数据的托架必须用有效的表示carriage_sequencenum ber 和没有数据的字段应该被省略（或者，这些字段也可以被包括并设置为“无数据”值）。<br/><br/>**警告：**这个领域仍然**实验**，并且可能会发生变化。将来可能会正式采用。 |
+| **id**                   | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 可選的       | 一        | 車廂的識別。每個應該是唯一的vehicle.<br/><br/>**警告：**這個領域仍然**實驗**，並且可能會發生變化。將來可能會正式採用。 |
+| **label**                | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 可選的       | 一        | 用戶可見label可能會顯示給乘客以幫助識別車廂。示例：“7712”、“汽車 ABC-32”等...<br/>**警告：**這個領域仍然**實驗**，並且可能會發生變化。將來可能會正式採用。 |
+| **occupancy_status**     | [OccupancyStatus](#enum-occupancystatus)                                   | 可選的       | 一        | 此給定車廂的佔用狀態，在此vehicle.默認設置為`NO_DATA_AVAILABLE` .<br/><br/>**警告：**這個領域仍然**實驗**，並且可能會發生變化。將來可能會正式採用。 |
+| **occupancy_percentage** | [int32](https://developers.google.com/protocol-buffers/docs/proto#scalar)  | 可選的       | 一        | 這個給定車廂的佔用百分比，在這個vehicle.遵循與“VehiclePosition.occupancy_percentage”相同的規則。如果該給定托架的數據不可用，請使用 -1。 <br/><br/>**警告：**這個領域仍然**實驗**，並且可能會發生變化。將來可能會正式採用。 |
+| **carriage_sequence**    | [uint32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 必需的       | 一        | 識別該車廂相對於其他車廂的順序vehicle的 CarriageStatus 列表。行進方向上的第一個托架的值必須為 1。第二個值對應於行進方向上的第二個托架，值必須為 2，依此類推。例如，行駛方向的第一節車廂的值為 1。如果行駛方向的第二節車廂的值為 3，則消費者將丟棄所有車廂的數據（即multi_carriage_details場地）。沒有數據的托架必須用有效的表示carriage_sequencenum ber 和沒有數據的字段應該被省略（或者，這些字段也可以被包括並設置為“無數據”值）。 <br/><br/>**警告：**這個領域仍然**實驗**，並且可能會發生變化。將來可能會正式採用。 |
 
 ## message Alert
 
-一个Alert，表示公共交通网络中的某种事件。
+一個Alert，表示公共交通網絡中的某種事件。
 
 **字段**
 
-| _**字段名称**_                 | _**类型**_                                      | _**必需的**_ | _**基数**_ | _**描述**_                                                                                                                                                                                    |
+| _**字段名稱**_                 | _**類型**_                                      | _**必需的**_ | _**基數**_ | _**描述**_                                                                                                                                                                                    |
 | -------------------------- | --------------------------------------------- | --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **active_period**          | [TimeRange](#message-timerange)               | 可选的       | 许多       | time当。。。的时候Alert应该显示给用户。如果丢失，则Alert只要它出现在提要中，就会显示出来。如果给出多个范围，则Alert将在所有期间显示。                                                                                                                |
-| **informed_entity**        | [EntitySelector](#message-entityselector)     | 必需的       | 许多       | 我们应该通知其用户的实体Alert.最后一个informed_entity必须提供。                                                                                                                                                  |
-| **Cause**                  | [Cause](#enum-cause)                          | 有条件要求     | 一        | 如果包含 cause_detail，则Cause也必须包括在内。                                                                                                                                                            |
-| **原因详细信息**                 | [TranslatedString](#message-translatedstring) | 可选的       | 一        | 描述Cause的Alert允许特定于机构的language;比Cause.如果包含 cause_detail，则Cause也必须包括在内。<br/><br/>**警告：**这个领域仍然**实验**，并且可能会发生变化。将来可能会正式采用。                                                                     |
-| **Effect**                 | [Effect](#enum-effect)                        | 有条件要求     | 一        | 如果包含 effect_detail，则Effect也必须包括在内。                                                                                                                                                          |
-| **效果细节**                   | [TranslatedString](#message-translatedstring) | 可选的       | 一        | 描述Effect的Alert允许特定于机构的language;比Effect.如果包含 effect_detail，则Effect也必须包括在内。<br/><br/>**警告：**这个领域仍然**实验**，并且可能会发生变化。将来可能会正式采用。                                                                 |
-| **url**                    | [TranslatedString](#message-translatedstring) | 可选的       | 一        | 这url它提供了有关Alert.                                                                                                                                                                            |
-| **header_text**            | [TranslatedString](#message-translatedstring) | 必需的       | 一        | header为了Alert.这朴素——textstring将突出显示，例如以粗体显示。                                                                                                                                                 |
-| **description_text**       | [TranslatedString](#message-translatedstring) | 必需的       | 一        | 说明Alert.这朴素——textstring将被格式化为Alert（或在用户明确的“扩展”请求中显示）。描述中的信息应添加到header.                                                                                                                      |
-| **tts_header_text**        | [TranslatedString](#message-translatedstring) | 可选的       | 一        | text包含Alert的header用于text到语音的实现。这个字段是text- 到语音版本header_text.它应该包含与header_text但格式化为可以读取为text-to-speech（例如，删除的缩写、拼出的数字等）                                                                       |
-| **tts_description_text**   | [TranslatedString](#message-translatedstring) | 可选的       | 一        | text包含对Alert用于text到语音的实现。这个字段是text- 到语音版本description_text.它应该包含与description_text但格式化为可以读取为text-to-speech（例如，删除的缩写、拼出的数字等）                                                                   |
-| **severity_level**         | [SeverityLevel](#enum-severitylevel)          | 可选的       | 一        | 的严重性Alert.                                                                                                                                                                                  |
-| **image**                  | [TranslatedImage](#message-translatedimage)   | 可选的       | 一        | TranslatedImage沿线显示Alerttext.用于直观地解释AlertEffect一个DETOUR，车站关闭等。image应该加强对Alert并且不能是重要信息的唯一位置。不鼓励使用以下类型的图像：image主要包含text、营销或品牌图像，不添加任何附加信息。<br/><br/>**警告：**这个领域仍然**实验**，并且可能会发生变化。将来可能会正式采用。 |
-| **image_alternative_text** | [TranslatedString](#message-translatedstring) | 可选的       | 一        | text描述链接的外观image在里面`image`字段（例如，如果image无法显示或用户看不到image出于可访问性的原因）。见 HTML[替代规范imagetext](https://html.spec.whatwg.org/#alt) .<br/><br/>**警告：**这个领域仍然**实验**，并且可能会发生变化。将来可能会正式采用。               |
+| **active_period**          | [TimeRange](#message-timerange)               | 可選的       | 許多       | time當。 。 。的時候Alert應該顯示給用戶。如果丟失，則Alert只要它出現在提要中，就會顯示出來。如果給出多個範圍，則Alert將在所有期間顯示。 |
+| **informed_entity**        | [EntitySelector](#message-entityselector)     | 必需的       | 許多       |我們應該通知其用戶的實體Alert.最後一個informed_entity必須提供。 |
+| **Cause**                  | [Cause](#enum-cause)                          | 有條件要求     | 一        | 如果包含 cause_detail，則Cause也必須包括在內。 |
+| **原因詳細信息**                 | [TranslatedString](#message-translatedstring) | 可選的       | 一        | 描述Cause的Alert允許特定於機構的language;比Cause.如果包含 cause_detail，則Cause也必須包括在內。 <br/><br/>**警告：**這個領域仍然**實驗**，並且可能會發生變化。將來可能會正式採用。 |
+| **Effect**                 | [Effect](#enum-effect)                        | 有條件要求     | 一        | 如果包含 effect_detail，則Effect也必須包括在內。 |
+| **效果細節**                   | [TranslatedString](#message-translatedstring) | 可選的       | 一        | 描述Effect的Alert允許特定於機構的language;比Effect.如果包含 effect_detail，則Effect也必須包括在內。 <br/><br/>**警告：**這個領域仍然**實驗**，並且可能會發生變化。將來可能會正式採用。 |
+| **url**                    | [TranslatedString](#message-translatedstring) | 可選的       | 一        | 這url它提供了有關Alert.                                                                                                                                                                            |
+| **header_text**            | [TranslatedString](#message-translatedstring) | 必需的       | 一        | header為了Alert.這樸素——textstring將突出顯示，例如以粗體顯示。 |
+| **description_text**       | [TranslatedString](#message-translatedstring) | 必需的       | 一        | 說明Alert.這樸素——textstring將被格式化為Alert（或在用戶明確的“擴展”請求中顯示）。描述中的信息應添加到header.                                                                                                                      |
+| **tts_header_text**        | [TranslatedString](#message-translatedstring) | 可選的       | 一        | text包含Alert的header用於text到語音的實現。這個字段是text- 到語音版本header_text.它應該包含與header_text但格式化為可以讀取為text-to-speech（例如，刪除的縮寫、拼出的數字等）                                                                       |
+| **tts_description_text**   | [TranslatedString](#message-translatedstring) | 可選的       | 一        | text包含對Alert用於text到語音的實現。這個字段是text- 到語音版本description_text.它應該包含與description_text但格式化為可以讀取為text-to-speech（例如，刪除的縮寫、拼出的數字等）                                                                   |
+| **severity_level**         | [SeverityLevel](#enum-severitylevel)          | 可選的       | 一        | 的嚴重性Alert.                                                                                                                                                                                  |
+| **image**                  | [TranslatedImage](#message-translatedimage)   | 可選的       | 一        | TranslatedImage沿線顯示Alerttext.用於直觀地解釋AlertEffect一個DETOUR，車站關閉等。 image應該加強對Alert並且不能是重要信息的唯一位置。不鼓勵使用以下類型的圖像：image主要包含text、營銷或品牌圖像，不添加任何附加信息。 <br/><br/>**警告：**這個領域仍然**實驗**，並且可能會發生變化。將來可能會正式採用。 |
+| **image_alternative_text** | [TranslatedString](#message-translatedstring) | 可選的       | 一        | text描述鏈接的外觀image在裡面`image`字段（例如，如果image無法顯示或用戶看不到image出於可訪問性的原因）。見 HTML[替代規範imagetext](https://html.spec.whatwg.org/#alt) .<br/><br/>**警告：**這個領域仍然**實驗**，並且可能會發生變化。將來可能會正式採用。 |
 
 
 ## enum Cause
 
-Cause这个的Alert.
+Cause這個的Alert.
 
-**价值观**
+**價值觀**
 
-| _**价值**_              |
+| _**價值**_              |
 | --------------------- |
 | **UNKNOWN_CAUSE**     |
 | **OTHER_CAUSE**       |
@@ -382,11 +382,11 @@ Cause这个的Alert.
 
 ## enum Effect
 
-这Effect这个问题对受影响的entity.
+這Effect這個問題對受影響的entity.
 
-**价值观**
+**價值觀**
 
-| _**价值**_                |
+| _**價值**_                |
 | ----------------------- |
 | **NO_SERVICE**          |
 | **REDUCED_SERVICE**     |
@@ -402,13 +402,13 @@ Cause这个的Alert.
 
 ## enum SeverityLevel
 
-的严重性Alert.
+的嚴重性Alert.
 
-**注意：**此字段仍处于**试验阶段**，可能会发生变化。将来可能会正式采用。
+**注意：**此字段仍處於**試驗階段**，可能會發生變化。將來可能會正式採用。
 
-**价值观**
+**價值觀**
 
-| _**价值**_             |
+| _**價值**_             |
 | -------------------- |
 | **UNKNOWN_SEVERITY** |
 | **INFO**             |
@@ -417,173 +417,173 @@ Cause这个的Alert.
 
 ## message TimeRange
 
-一个time间隔。间隔被认为是活跃的time`t`如果`t`大于或等于starttime并且小于endtime.
+一個time間隔。間隔被認為是活躍的time`t`如果`t`大於或等於starttime並且小於endtime.
 
 **字段**
 
-| _**字段名称**_ | _**类型**_                                                                   | _**必需的**_ | _**基数**_ | _**描述**_                                                                                                                        |
+| _**字段名稱**_ | _**類型**_                                                                   | _**必需的**_ | _**基數**_ | _**描述**_|
 | ---------- | -------------------------------------------------------------------------- | --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| **start**  | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有条件要求     | 一        | starttime, 在 POSIX 中time（即自 1970 年 1 月 1 日 00:00:00 UTC 以来的秒数）。如果缺失，则间隔从负无穷大开始。如果一个TimeRange提供，要么start或者end必须提供 - 两个字段都不能EMPTY. |
-| **end**    | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有条件要求     | 一        | endtime, 在 POSIX 中time（即自 1970 年 1 月 1 日 00:00:00 UTC 以来的秒数）。如果缺失，则间隔以正无穷大结束。如果一个TimeRange提供，要么start或者end必须提供 - 两个字段都不能EMPTY.   |
+| **start**  | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有條件要求     | 一        | starttime, 在 POSIX 中time（即自 1970 年 1 月 1 日 00:00:00 UTC 以來的秒數）。如果缺失，則間隔從負無窮大開始。如果一個TimeRange提供，要么start或者end必須提供 - 兩個字段都不能EMPTY. |
+| **end**    | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有條件要求     | 一        | endtime, 在 POSIX 中time（即自 1970 年 1 月 1 日 00:00:00 UTC 以來的秒數）。如果缺失，則間隔以正無窮大結束。如果一個TimeRange提供，要么start或者end必須提供 - 兩個字段都不能EMPTY.   |
 
 ## message Position
 
-一个地理Position一个vehicle.
+一個地理Position一個vehicle.
 
 **字段**
 
-| _**字段名称**_    | _**类型**_                                                                   | _**必需的**_ | _**基数**_ | _**描述**_                                                                                             |
+| _**字段名稱**_    | _**類型**_                                                                   | _**必需的**_ | _**基數**_ | _**描述**_                                                                                             |
 | ------------- | -------------------------------------------------------------------------- | --------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| **latitude**  | [float](https://developers.google.com/protocol-buffers/docs/proto#scalar)  | 必需的       | 一        | 北度数，在 WGS-84 坐标系中。                                                                                   |
-| **longitude** | [float](https://developers.google.com/protocol-buffers/docs/proto#scalar)  | 必需的       | 一        | 东度，在 WGS-84 坐标系中。                                                                                    |
-| **bearing**   | [float](https://developers.google.com/protocol-buffers/docs/proto#scalar)  | 可选的       | 一        | bearing，以度为单位，从真北顺时针方向，即，0 是北，90 是东。这可以是指南针bearing，或朝向下一站或中间位置的方向。这不应该从先前位置的序列中推断出来，客户可以从先前的数据中计算出来。 |
-| **odometer**  | [double](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 可选的       | 一        | odometer值，以米为单位。                                                                                     |
-| **speed**     | [float](https://developers.google.com/protocol-buffers/docs/proto#scalar)  | 可选的       | 一        | 瞬间speed由测量vehicle，以米/秒为单位。                                                                           |
+| **latitude**  | [float](https://developers.google.com/protocol-buffers/docs/proto#scalar)  | 必需的       | 一        | 北度數，在 WGS-84 坐標系中。 |
+| **longitude** | [float](https://developers.google.com/protocol-buffers/docs/proto#scalar)  | 必需的       | 一        | 東度，在 WGS-84 坐標系中。 |
+| **bearing**   | [float](https://developers.google.com/protocol-buffers/docs/proto#scalar)  | 可選的       | 一        | bearing，以度為單位，從真北順時針方向，即，0 是北，90 是東。這可以是指南針bearing，或朝向下一站或中間位置的方向。這不應該從先前位置的序列中推斷出來，客戶可以從先前的數據中計算出來。 |
+| **odometer**  | [double](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 可選的       | 一        | odometer值，以米為單位。 |
+| **speed**     | [float](https://developers.google.com/protocol-buffers/docs/proto#scalar)  | 可選的       | 一        | 瞬間speed由測量vehicle，以米/秒為單位。 |
 
 
 ## message TripDescriptor
 
-标识单个实例的描述符GTFStrip.
+標識單個實例的描述符GTFStrip.
 
-指定单个trip例如，在许多情况下trip_id本身就足够了。但是，以下情况需要额外的信息才能解决单个trip实例：
+指定單個trip例如，在許多情況下trip_id本身就足夠了。但是，以下情況需要額外的信息才能解決單個trip實例：
 
-* 对于定义的行程frequencies.txt ,start_date和start_time除了需要trip_id
-* 如果trip持续超过 24 小时，或被延迟以致与SCHEDULEDtrip第二天，然后start_date除了需要trip_id
-* 如果trip_id无法提供字段，则route_id ,direction_id ,start_date ， 和start_time必须全部提供
+* 對於定義的行程frequencies.txt ,start_date和start_time除了需要trip_id
+* 如果trip持續超過 24 小時，或被延遲以致與SCHEDULEDtrip第二天，然後start_date除了需要trip_id
+* 如果trip_id無法提供字段，則route_id ,direction_id ,start_date ， 和start_time必須全部提供
 
-在所有情况下，如果route_id除了提供trip_id ，那么route_id必须相同route_id分配给给定的trip在GTFStrips.txt .
+在所有情況下，如果route_id除了提供trip_id ，那麼route_id必須相同route_id分配給給定的trip在GTFStrips.txt .
 
-这trip_id字段不能单独或与其他字段组合TripDescriptor字段，用于识别多个trip实例。例如，一个TripDescriptor永远不应该指定trip_id本身为GTFSfrequencies.txt exact_times=0 次因为start_time也需要解决一个单一的trip实例开始于特定time的一天。如果TripDescriptor不解决单个trip实例（即，它解析为零或多个trip实例），它被认为是一个错误和entity包含错误的TripDescriptor可能会被消费者丢弃。
+這trip_id字段不能單獨或與其他字段組合TripDescriptor字段，用於識別多個trip實例。例如，一個TripDescriptor永遠不應該指定trip_id本身為GTFSfrequencies.txt exact_times=0 次因為start_time也需要解決一個單一的trip實例開始於特定time的一天。如果TripDescriptor不解決單個trip實例（即，它解析為零或多個trip實例），它被認為是一個錯誤和entity包含錯誤的TripDescriptor可能會被消費者丟棄。
 
-请注意，如果trip_id未知，则站序列 id 在TripUpdate还不够，还必须提供 stop_ids。此外，绝对arrival/departure必须提供时间。
+請注意，如果trip_id未知，則站序列 id 在TripUpdate還不夠，還必須提供 stop_ids。此外，絕對arrival/departure必須提供時間。
 
-TripDescriptor.route_id不能在一个内使用AlertEntitySelector指定路由范围Alert影响路线的所有行程 - 使用EntitySelector.route_id反而。
+TripDescriptor.route_id不能在一個內使用AlertEntitySelector指定路由范圍Alert影響路線的所有行程 - 使用EntitySelector.route_id反而。
 
 
 **字段**
 
-| _**字段名称**_                | _**类型**_                                                                   | _**必需的**_ | _**基数**_ | _**描述**_                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| _**字段名稱**_                | _**類型**_                                                                   | _**必需的**_ | _**基數**_ | _**描述**_                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | ------------------------- | -------------------------------------------------------------------------- | --------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **trip_id**               | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有条件要求     | 一        | 这trip_id来自GTFS此选择器引用的提要。对于非基于频率的旅行（未在GTFSfrequencies.txt )，该字段足以唯一标识trip.对于定义的基于频率的行程GTFSfrequencies.txt ,trip_id ,start_time， 和start_date都是必需的。为了SCHEDULED-基于旅行（旅行未定义在GTFSfrequencies.txt ),trip_id仅当trip可以通过以下组合唯一标识route_id ,direction_id,start_time， 和start_date，并且提供了所有这些字段。什么时候schedule_relationship是DUPLICATED在一个TripUpdate， 这trip_id标识trip从静态GTFS成为DUPLICATED.什么时候schedule_relationship是DUPLICATED在一个VehiclePosition， 这trip_id标识新的副本trip并且必须包含对应的值TripUpdate.TripProperties .trip_id .                                                       |
-| **route_id**              | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有条件要求     | 一        | 这route_id来自GTFS这个选择器所指的。如果trip_id被省略，route_id ,direction_id,start_time, 和 schedule_relationship=SCHEDULED必须全部设置为识别一个trip实例。TripDescriptor.route_id不应该在一个内使用AlertEntitySelector指定路由范围Alert影响路线的所有行程 - 使用EntitySelector.route_id反而。                                                                                                                                                                                                                                                                                                                    |
-| **direction_id**          | [uint32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有条件要求     | 一        | 这direction_id来自GTFS喂养trips.txt文件，指示此选择器所指的行程的行进方向。如果trip_id被省略，direction_id必须提供。<br/><br/>**警告：**这个领域仍然**实验**，并且可能会发生变化。将来可能会正式采用。<br/>                                                                                                                                                                                                                                                                                                                                                                                                              |
-| **start_time**            | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有条件要求     | 一        | 最初的SCHEDULEDstarttime这个的trip实例。当。。。的时候trip_id对应于非基于频率的trip，此字段应省略或等于GTFS喂养。当。。。的时候trip_id对应于基于频率的trip定义在GTFSfrequencies.txt ,start_time是必需的，必须指定为trip更新和vehicle职位。如果trip对应于exact_times=1GTFS记录，然后start_time必须是 headway_secs 的某个倍数（包括零）frequencies.txtstart_time对于相应的time时期。如果trip对应于exact_times=0，那么它的start_time可能是任意的，最初预计是第一个departure的trip.一经成立，start_time这个基于频率的exact_times=0trip应该被认为是不可变的，即使第一个departuretime变化——那time相反，变化可能会反映在StopTimeUpdate.如果trip_id被省略，start_time必须提供。该字段的格式和语义与GTFS /frequencies.txt /start_time，例如 11:15:35 或 25:15:35。 |
-| **start_date**            | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有条件要求     | 一        | 这start这个日期tripYYYYMMDD 格式的实例。为了SCHEDULED行程（行程未在GTFSfrequencies.txt )，必须提供此字段以消除迟到以至于与SCHEDULEDtrip第二天。例如，对于每天 8:00 和 20:00 出发且晚点 12 小时的火车，同一班次会有两个不同的行程time.可以提供此字段，但对于不可能发生此类冲突的计划（例如，按小时计划运行的服务，其中一个vehicle迟到一小时不再被认为与日程安排有关。此字段对于定义的基于频率的行程是必需的GTFSfrequencies.txt .如果trip_id被省略，start_date必须提供。                                                                                                                                                                                                                                                  |
-| **schedule_relationship** | [ScheduleRelationship](#enum-schedulerelationship-1)                       | 可选的       | 一        | 这之间的关系trip和静态时间表。如果TripDescriptor提供在一个Alert`EntitySelector`， 这`schedule_relationship`消费者在识别匹配时忽略该字段trip实例。                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| **trip_id**               | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有條件要求     | 一        | 這trip_id來自GTFS此選擇器引用的提要。對於非基於頻率的旅行（未在GTFSfrequencies.txt )，該字段足以唯一標識trip.對於定義的基於頻率的行程GTFSfrequencies.txt ,trip_id ,start_time， 和start_date都是必需的。為了SCHEDULED-基於旅行（旅行未定義在GTFSfrequencies.txt ),trip_id僅當trip可以通過以下組合唯一標識route_id ,direction_id,start_time， 和start_date，並且提供了所有這些字段。什麼時候schedule_relationship是DUPLICATED在一個TripUpdate， 這trip_id標識trip從靜態GTFS成為DUPLICATED.什麼時候schedule_relationship是DUPLICATED在一個VehiclePosition， 這trip_id標識新的副本trip並且必須包含對應的值TripUpdate.TripProperties .trip_id .                                                       |
+| **route_id**              | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有條件要求     | 一        | 這route_id來自GTFS這個選擇器所指的。如果trip_id被省略，route_id ,direction_id,start_time, 和 schedule_relationship=SCHEDULED必須全部設置為識別一個trip實例。 TripDescriptor.route_id不應該在一個內使用AlertEntitySelector指定路由范圍Alert影響路線的所有行程 - 使用EntitySelector.route_id反而。 |
+| **direction_id**          | [uint32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有條件要求     | 一        | 這direction_id來自GTFS餵養trips.txt文件，指示此選擇器所指的行程的行進方向。如果trip_id被省略，direction_id必須提供。 <br/><br/>**警告：**這個領域仍然**實驗**，並且可能會發生變化。將來可能會正式採用。 <br/>                                                                                                                                                                                                                                                                                                                                                                                                              |
+| **start_time**            | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有條件要求     | 一        | 最初的SCHEDULEDstarttime這個的trip實例。當。 。 。的時候trip_id對應於非基於頻率的trip，此字段應省略或等於GTFS餵養。當。 。 。的時候trip_id對應於基於頻率的trip定義在GTFSfrequencies.txt ,start_time是必需的，必須指定為trip更新和vehicle職位。如果trip對應於exact_times=1GTFS記錄，然後start_time必須是 headway_secs 的某個倍數（包括零）frequencies.txtstart_time對於相應的time時期。如果trip對應於exact_times=0，那麼它的start_time可能是任意的，最初預計是第一個departure的trip.一經成立，start_time這個基於頻率的exact_times=0trip應該被認為是不可變的，即使第一個departuretime變化——那time相反，變化可能會反映在StopTimeUpdate.如果trip_id被省略，start_time必須提供。該字段的格式和語義與GTFS /frequencies.txt /start_time，例如 11:15:35 或 25:15:35。 |
+| **start_date**            | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有條件要求     | 一        | 這start這個日期tripYYYYMMDD 格式的實例。為了SCHEDULED行程（行程未在GTFSfrequencies.txt )，必須提供此字段以消除遲到以至於與SCHEDULEDtrip第二天。例如，對於每天 8:00 和 20:00 出發且晚點 12 小時的火車，同一班次會有兩個不同的行程time.可以提供此字段，但對於不可能發生此類衝突的計劃（例如，按小時計劃運行的服務，其中一個vehicle遲到一小時不再被認為與日程安排有關。此字段對於定義的基於頻率的行程是必需的GTFSfrequencies.txt .如果trip_id被省略，start_date必須提供。                                                                                                                                                                                                                                                  |
+| **schedule_relationship** | [ScheduleRelationship](#enum-schedulerelationship-1)                       | 可選的       | 一        | 這之間的關係trip和靜態時間表。如果TripDescriptor提供在一個Alert`EntitySelector`， 這`schedule_relationship`消費者在識別匹配時忽略該字段trip實例。 |
 
 
 ## enum ScheduleRelationship
 
-这之间的关系trip和静态时间表。如果一个trip是按照临时时间表完成的，没有反映在GTFS ，那么它不应该被标记为SCHEDULED, 但标记为ADDED.
+這之間的關係trip和靜態時間表。如果一個trip是按照臨時時間表完成的，沒有反映在GTFS ，那麼它不應該被標記為SCHEDULED, 但標記為ADDED.
 
-**价值观**
+**價值觀**
 
-| _**价值**_        | _**评论**_                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| _**價值**_        | _**評論**_                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **SCHEDULED**   | trip即按照其运行GTFS Schedule，或者足够接近SCHEDULEDtrip与它相关联。                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| **ADDED**       | 一个额外的trip那是ADDED除了运行计划之外，例如，替换损坏的vehicle或应对突然的载客量。_注意：目前，未指定使用此模式的提要的行为。有关于的讨论GTFS GitHub[ (1)](https://github.com/google/transit/issues/106) [ (2)](https://github.com/google/transit/pull/221) [ (3)](https://github.com/google/transit/pull/219)围绕完全指定或弃用ADDED旅行和文件将在这些讨论完成后更新。_                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| **UNSCHEDULED** | 一个trip正在运行且没有与之关联的时间表 - 此值用于识别定义的行程GTFSfrequencies.txt精确时间 = 0。它不应用于描述未定义的行程GTFSfrequencies.txt , 或旅行GTFSfrequencies.txt精确时间 = 1。`schedule_relationship: UNSCHEDULED`还必须设置所有 StopTimeUpdates`schedule_relationship: UNSCHEDULED`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| **CANCELED**    | 一个trip存在于计划中但已被删除。                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| **DUPLICATED**  | 一个新的trip这与现有的相同SCHEDULEDtrip除了服务start日期和time.与`TripUpdate.TripProperties.trip_id` ,`TripUpdate.TripProperties.start_date`， 和`TripUpdate.TripProperties.start_time`复制现有的trip从静态GTFS但start在不同的服务日期和/或time.复制一个trip如果与原始服务相关，则允许trip在 (CSV)GTFS （在`calendar.txt`或者`calendar_dates.txt`) 在接下来的 30 天内运营。这trip成为DUPLICATED通过识别`TripUpdate.TripDescriptor.trip_id` .<br/><br/>此枚举不修改现有的trip被引用`TripUpdate.TripDescriptor.trip_id`- 如果制片人想取消原作trip, 它必须单独发布`TripUpdate`与价值CANCELED.行程定义在GTFS`frequencies.txt`和`exact_times`那是EMPTY或等于`0`不可能是DUPLICATED.这`VehiclePosition.TripDescriptor.trip_id`对于新的trip必须包含来自的匹配值`TripUpdate.TripProperties.trip_id`和`VehiclePosition.TripDescriptor.ScheduleRelationship`还必须设置为`DUPLICATED`.<br/><br/>_现有的生产者和消费者正在使用ADDED枚举来表示DUPLICATED旅行必须遵循[迁移指南](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/examples/migration-duplicated.md)过渡到DUPLICATED枚举。_ |
+| **SCHEDULED**   | trip即按照其運行GTFS Schedule，或者足夠接近SCHEDULEDtrip與它相關聯。 |
+| **ADDED**       | 一個額外的trip那是ADDED除了運行計劃之外，例如，替換損壞的vehicle或應對突然的載客量。 _注意：目前，未指定使用此模式的提要的行為。有關於的討論GTFS GitHub[ (1)](https://github.com/google/transit/issues/106) [ (2)](https://github.com/google/transit/pull/221) [ (3)](https://github.com/google/transit/pull/219)圍繞完全指定或棄用ADDED旅行和文件將在這些討論完成後更新。 _                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| **UNSCHEDULED** | 一個trip正在運行且沒有與之關聯的時間表 - 此值用於識別定義的行程GTFSfrequencies.txt精確時間 = 0。它不應用於描述未定義的行程GTFSfrequencies.txt , 或旅行GTFSfrequencies.txt精確時間 = 1。 `schedule_relationship: UNSCHEDULED`還必須設置所有 StopTimeUpdates`schedule_relationship: UNSCHEDULED`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| **CANCELED**    | 一個trip存在於計劃中但已被刪除。 |
+| **DUPLICATED**  | 一個新的trip這與現有的相同SCHEDULEDtrip除了服務start日期和time.與`TripUpdate.TripProperties.trip_id` ,`TripUpdate.TripProperties.start_date`， 和`TripUpdate.TripProperties.start_time`複製現有的trip從靜態GTFS但start在不同的服務日期和/或time.複製一個trip如果與原始服務相關，則允許trip在 (CSV)GTFS （在`calendar.txt`或者`calendar_dates.txt`) 在接下來的 30 天內運營。這trip成為DUPLICATED通過識別`TripUpdate.TripDescriptor.trip_id` .<br/><br/>此枚舉不修改現有的trip被引用`TripUpdate.TripDescriptor.trip_id`- 如果製片人想取消原作trip, 它必須單獨發布`TripUpdate`與價值CANCELED.行程定義在GTFS`frequencies.txt`和`exact_times`那是EMPTY或等於`0`不可能是DUPLICATED.這`VehiclePosition.TripDescriptor.trip_id`對於新的trip必須包含來自的匹配值`TripUpdate.TripProperties.trip_id`和`VehiclePosition.TripDescriptor.ScheduleRelationship`還必須設置為`DUPLICATED`.<br/><br/>_現有的生產者和消費者正在使用ADDED枚舉來表示DUPLICATED旅行必須遵循[遷移指南](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/examples/migration-duplicated.md)過渡到DUPLICATED枚舉。 _ |
 
 
 ## message VehicleDescriptor
 
-身份识别信息vehicle执行trip.
+身份識別信息vehicle執行trip.
 
 **字段**
 
-| _**字段名称**_        | _**类型**_                                                                   | _**必需的**_ | _**基数**_ | _**描述**_                                                                                |
+| _**字段名稱**_        | _**類型**_                                                                   | _**必需的**_ | _**基數**_ | _**描述**_                                                                                |
 | ----------------- | -------------------------------------------------------------------------- | --------- | -------- | --------------------------------------------------------------------------------------- |
-| **id**            | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 可选的       | 一        | 内部系统识别vehicle.应该**独特的**每vehicle, 并用于跟踪vehicle当它通过系统进行时。这个id不应该对end-用户;为此目的使用**label**场地 |
-| **label**         | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 可选的       | 一        | 用户可见label，即必须向乘客展示以帮助识别正确的东西vehicle.                                                    |
-| **license_plate** | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 可选的       | 一        | 车牌号vehicle.                                                                             |
-| **无障碍通道**         | [无障碍通道](#enum-wheelchairaccessible)                                        | 可选的       | 一        | 如果提供，可以覆盖_无障碍通道_静态值GTFS .                                                               |
+| **id**            | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 可選的       | 一        | 內部系統識別vehicle.應該**獨特的**每vehicle, 並用於跟踪vehicle當它通過系統進行時。這個id不應該對end-用戶;為此目的使用**label**場地 |
+| **label**         | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 可選的       | 一        | 用戶可見label，即必須向乘客展示以幫助識別正確的東西vehicle.                                                    |
+| **license_plate** | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 可選的       | 一        | 車牌號vehicle.                                                                             |
+| **無障礙通道**         | [無障礙通道](#enum-wheelchairaccessible)                                        | 可選的       | 一        | 如果提供，可以覆蓋_無障礙通道_靜態值GTFS .                                                               |
 
-## enum 无障碍通道
+## enum 無障礙通道
 
-如果一个特别的trip可供轮椅使用。如果可用，此值应覆盖静态中的_Wheelchair_accessible_值GTFS .
+如果一個特別的trip可供輪椅使用。如果可用，此值應覆蓋靜態中的_Wheelchair_accessible_值GTFS .
 
-**价值观**
+**價值觀**
 
-| _**价值**_    | _**评论**_                                                  |
+| _**價值**_    | _**評論**_                                                  |
 | ----------- | --------------------------------------------------------- |
-| **没有价值**    | 这trip没有关于轮椅无障碍的信息。这是**默认**行为。如果静电GTFS包含一个_无障碍通道_值，它不会被覆盖。 |
-| **未知**      | 这trip不存在可访问性值。此值将覆盖从GTFS .                                |
-| **无障碍通道**   | 这trip轮椅可通行。此值将覆盖从GTFS .                                   |
-| **轮椅_无法访问** | 这trip是**不是**无障碍通道。此值将覆盖从GTFS .                            |
+| **沒有價值**    | 這trip沒有關於輪椅無障礙的信息。這是**默認**行為。如果靜電GTFS包含一個_無障礙通道_值，它不會被覆蓋。 |
+| **未知**      | 這trip不存在可訪問性值。此值將覆蓋從GTFS .                                |
+| **無障礙通道**   | 這trip輪椅可通行。此值將覆蓋從GTFS .                                   |
+| **輪椅_無法訪問** | 這trip是**不是**無障礙通道。此值將覆蓋從GTFS .                            |
 
 
 ## message EntitySelector
 
-一个选择器entity在一个GTFS喂养。字段的值应对应于相应的字段GTFS喂养。必须至少给出一个说明符。如果给出了几个，则应将它们解释为由逻辑`AND`运算符连接。此外，说明符的组合必须与GTFS喂养。换句话说，为了一个Alert适用于entity在GTFS它必须匹配所有提供的EntitySelector字段。例如，一个EntitySelector包括字段route_id `route_id : "5"`和route_type `route_type : "3"`仅适用于route_id `route_id : "5"` bus - 它不适用于任何其他路线route_type `route_type : "3"` 。如果生产者想要一个Alert申请route_id `route_id : "5"`以及route_type `route_type : "3"` ，它应该提供两个独立的EntitySelector，一个引用route_id `route_id : "5"`和另一个引用route_type `route_type : "3"` 。
+一個選擇器entity在一個GTFS餵養。字段的值應對應於相應的字段GTFS餵養。必須至少給出一個說明符。如果給出了幾個，則應將它們解釋為由邏輯`AND`運算符連接。此外，說明符的組合必須與GTFS餵養。換句話說，為了一個Alert適用於entity在GTFS它必須匹配所有提供的EntitySelector字段。例如，一個EntitySelector包括字段route_id `route_id : "5"`和route_type `route_type : "3"`僅適用於route_id `route_id : "5"` bus - 它不適用於任何其他路線route_type `route_type : "3"` 。如果生產者想要一個Alert申請route_id `route_id : "5"`以及route_type `route_type : "3"` ，它應該提供兩個獨立的EntitySelector，一個引用route_id `route_id : "5"`和另一個引用route_type `route_type : "3"` 。
 
-必须给出至少一个说明符 - 一个字段中的所有字段EntitySelector不可能是EMPTY.
+必須給出至少一個說明符 - 一個字段中的所有字段EntitySelector不可能是EMPTY.
 
 **字段**
 
-| _**字段名称**_       | _**类型**_                                                                   | _**必需的**_ | _**基数**_ | _**描述**_                                                                                                                                                     |
+| _**字段名稱**_       | _**類型**_                                                                   | _**必需的**_ | _**基數**_ | _**描述**_                                                                                                                                                     |
 | ---------------- | -------------------------------------------------------------------------- | --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **agency_id**    | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有条件要求     | 一        | 这agency_id来自GTFS此选择器引用的提要。                                                                                                                                   |
-| **route_id**     | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有条件要求     | 一        | 这route_id来自GTFS这个选择器所指的。如果direction_id提供，route_id也必须提供。                                                                                                      |
-| **route_type**   | [int32](https://developers.google.com/protocol-buffers/docs/proto#scalar)  | 有条件要求     | 一        | 这route_type来自GTFS这个选择器所指的。                                                                                                                                   |
-| **direction_id** | [uint32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有条件要求     | 一        | 这direction_id来自GTFS喂养trips.txt文件，用于选择路线的一个方向上的所有行程，由指定route_id .如果direction_id提供，route_id也必须提供。<br/><br/>**警告：**这个领域仍然**实验**，并且可能会发生变化。将来可能会正式采用。<br/>       |
-| **trip**         | [TripDescriptor](#message-tripdescriptor)                                  | 有条件要求     | 一        | 这trip实例来自GTFS这个选择器所指的。这个TripDescriptor必须解决单个trip中的实例GTFS数据（例如，生产者不能只提供trip_id对于exact_times=0 行程）。如果ScheduleRelationship字段填充在此TripDescriptor消费者在尝试识别GTFStrip. |
-| **stop_id**      | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有条件要求     | 一        | 这stop_id来自GTFS此选择器引用的提要。                                                                                                                                     |
+| **agency_id**    | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有條件要求     | 一        | 這agency_id來自GTFS此選擇器引用的提要。 |
+| **route_id**     | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有條件要求     | 一        | 這route_id來自GTFS這個選擇器所指的。如果direction_id提供，route_id也必須提供。 |
+| **route_type**   | [int32](https://developers.google.com/protocol-buffers/docs/proto#scalar)  | 有條件要求     | 一        | 這route_type來自GTFS這個選擇器所指的。 |
+| **direction_id** | [uint32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有條件要求     | 一        | 這direction_id來自GTFS餵養trips.txt文件，用於選擇路線的一個方向上的所有行程，由指定route_id .如果direction_id提供，route_id也必須提供。 <br/><br/>**警告：**這個領域仍然**實驗**，並且可能會發生變化。將來可能會正式採用。 <br/>       |
+| **trip**         | [TripDescriptor](#message-tripdescriptor)                                  | 有條件要求     | 一        | 這trip實例來自GTFS這個選擇器所指的。這個TripDescriptor必須解決單個trip中的實例GTFS數據（例如，生產者不能只提供trip_id對於exact_times=0 行程）。如果ScheduleRelationship字段填充在此TripDescriptor消費者在嘗試識別GTFStrip. |
+| **stop_id**      | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有條件要求     | 一        | 這stop_id來自GTFS此選擇器引用的提要。 |
 
 ## message TranslatedString
 
-国际化的message 包含每language片段的版本text或一个url.来自 a 的字符串之一message 将被捡起。解决方法如下： 如果 UIlanguage匹配languagea的代码Translation, 第一个匹配Translation被选中。如果默认 UIlanguage（例如，英语）匹配languagea的代码Translation, 第一个匹配Translation被选中。如果有些Translation有一个未指定的language代码，那个Translation被选中。
+國際化的message 包含每language片段的版本text或一個url.來自 a 的字符串之一message 將被撿起。解決方法如下： 如果 UIlanguage匹配languagea的代碼Translation, 第一個匹配Translation被選中。如果默認 UIlanguage（例如，英語）匹配languagea的代碼Translation, 第一個匹配Translation被選中。如果有些Translation有一個未指定的language代碼，那個Translation被選中。
 
 
 **字段**
 
-| _**字段名称**_      | _**类型**_                            | _**必需的**_ | _**基数**_ | _**描述**_             |
+| _**字段名稱**_      | _**類型**_                            | _**必需的**_ | _**基數**_ | _**描述**_             |
 | --------------- | ----------------------------------- | --------- | -------- | -------------------- |
-| **Translation** | [Translation](#message-translation) | 必需的       | 许多       | 最后一个Translation必须提供。 |
+| **Translation** | [Translation](#message-translation) | 必需的       | 許多       | 最後一個Translation必須提供。 |
 
 ## message Translation
 
-本地化的string映射到一个language.
+本地化的string映射到一個language.
 
-| _**字段名称**_   | _**类型**_                                                                   | _**必需的**_ | _**基数**_ | _**描述**_                                                                                                                      |
+| _**字段名稱**_   | _**類型**_                                                                   | _**必需的**_ | _**基數**_ | _**描述**_                                                                                                                      |
 | ------------ | -------------------------------------------------------------------------- | --------- | -------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| **text**     | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 必需的       | 一        | 一个 UTF-8string包含message .                                                                                                      |
-| **language** | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有条件要求     | 一        |  BCP-47language代码。可以省略，如果language是未知的，或者是否根本没有对提要进行国际化。最多一个Translation允许有一个未指定的languagetag - 如果有多个Translation， 这language必须提供。 |
+| **text**     | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 必需的       | 一        | 一個 UTF-8string包含message .                                                                                                      |
+| **language** | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有條件要求     | 一        |  BCP-47language代碼。可以省略，如果language是未知的，或者是否根本沒有對提要進行國際化。最多一個Translation允許有一個未指定的languagetag - 如果有多個Translation， 這language必須提供。 |
 
 ## message TranslatedImage
 
-国际化的message 包含每language的版本image.其中一张图片来自message 将被捡起。解决方法如下： 如果 UIlanguage匹配languagea的代码Translation, 第一个匹配Translation被选中。如果默认 UIlanguage（例如，英语）匹配languagea的代码Translation, 第一个匹配Translation被选中。如果有些Translation有一个未指定的language代码，那个Translation被选中。
+國際化的message 包含每language的版本image.其中一張圖片來自message 將被撿起。解決方法如下： 如果 UIlanguage匹配languagea的代碼Translation, 第一個匹配Translation被選中。如果默認 UIlanguage（例如，英語）匹配languagea的代碼Translation, 第一個匹配Translation被選中。如果有些Translation有一個未指定的language代碼，那個Translation被選中。
 
-**注意：**这个message 仍处于**试验阶段**，可能会发生变化。将来可能会正式采用。
+**注意：**這個message 仍處於**試驗階段**，可能會發生變化。將來可能會正式採用。
 
 **字段**
 
-| _**字段名称**_          | _**类型**_                                  | _**必需的**_ | _**基数**_ | _**描述**_          |
+| _**字段名稱**_          | _**類型**_                                  | _**必需的**_ | _**基數**_ | _**描述**_          |
 | ------------------- | ----------------------------------------- | --------- | -------- | ----------------- |
-| **localized_image** | [LocalizedImage](#message-localizedimage) | 必需的       | 许多       | 至少一个本地化image必须提供。 |
+| **localized_image** | [LocalizedImage](#message-localizedimage) | 必需的       | 許多       | 至少一個本地化image必須提供。 |
 
 
 ## message LocalizedImage
 
-本地化的imageurl映射到一个language.
+本地化的imageurl映射到一個language.
 
-| _**字段名称**_     | _**类型**_                                                                   | _**必需的**_ | _**基数**_ | _**描述**_                                                                                                                                                                                                                                                                                                    |
+| _**字段名稱**_     | _**類型**_                                                                   | _**必需的**_ | _**基數**_ | _**描述**_                                                                                                                                                                                                                                                                                                    |
 | -------------- | -------------------------------------------------------------------------- | --------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **url**        | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 必需的       | 一        | string包含一个url链接到image.这image链接必须小于 2MB。如果image以足够显着的方式发生变化，需要在消费者端进行更新，生产者必须更新url到一个新的。<br/><br/>这url应该是完全合格的url包括 http:// 或 https:// 以及url必须正确转义。请参阅以下内容[http://www.w3.org/Addressing/url/4_URI_Recommentations.html 为](http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for)描述如何创建完全合格的url价值观。 |
-| **media_type** | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 必需的       | 一        | IANA media type as 指定的类型image要显示。类型必须start与“图像/”                                                                                                                                                                                                                                                            |
-| **language**   | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有条件要求     | 一        |  BCP-47language代码。可以省略，如果language是未知的，或者是否根本没有对提要进行国际化。最多一个Translation允许有一个未指定的languagetag - 如果有多个Translation， 这language必须提供。                                                                                                                                                                               |
+| **url**        | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 必需的       | 一        | string包含一個url鏈接到image.這image鏈接必須小於 2MB。如果image以足夠顯著的方式發生變化，需要在消費者端進行更新，生產者必須更新url到一個新的。 <br/><br/>這url應該是完全合格的url包括 http:// 或 https:// 以及url必須正確轉義。請參閱以下內容[http://www.w3.org/Addressing/url/4_URI_Recommentations.html 為](http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for)描述如何創建完全合格的url價值觀。 |
+| **media_type** | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 必需的       | 一        | IANA media type as 指定的類型image要顯示。類型必須start與“圖像/”                                                                                                                                                                                                                                                            |
+| **language**   | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 有條件要求     | 一        |  BCP-47language代碼。可以省略，如果language是未知的，或者是否根本沒有對提要進行國際化。最多一個Translation允許有一個未指定的languagetag - 如果有多個Translation， 這language必須提供。 |
 
 ## message Shape
 
-描述一个物理路径vehicle需要时Shape不属于 (CSV)GTFS ，例如对于临时DETOUR.形状属于 Trips，由编码的折线组成，以实现更有效的传输。 Shapes 不需要精确地截取 Stops 的位置，但所有 Stops 都在一个trip应该在一个小的距离内Shape为了那个原因trip，即接近连接的直线段Shape积分
+描述一個物理路徑vehicle需要時Shape不屬於 (CSV)GTFS ，例如對於臨時DETOUR.形狀屬於 Trips，由編碼的折線組成，以實現更有效的傳輸。 Shapes 不需要精確地截取 Stops 的位置，但所有 Stops 都在一個trip應該在一個小的距離內Shape為了那個原因trip，即接近連接的直線段Shape積分
 
-**注意：**这个message 仍处于**试验阶段**，可能会发生变化。将来可能会正式采用。<br/>.<br/>
+**注意：**這個message 仍處於**試驗階段**，可能會發生變化。將來可能會正式採用。 <br/>.<br/>
 
 
 **字段**
 
-| _**字段名称**_           | _**类型**_                                                                   | _**必需的**_ | _**基数**_ | _**描述**_                                                                                                                                                                   |
+| _**字段名稱**_           | _**類型**_                                                                   | _**必需的**_ | _**基數**_ | _**描述**_                                                                                                                                                                   |
 | -------------------- | -------------------------------------------------------------------------- | --------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **shape_id**         | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 必需的       | 一        | 标识符Shape.必须不同于任何`shape_id`在 (CSV) 中定义GTFS .<br/><br/>**警告：**这个领域仍然**实验**，并且可能会发生变化。将来可能会正式采用。                                                                              |
-| **encoded_polyline** | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 必需的       | 一        | 的编码折线表示Shape.此折线必须至少包含两个点。有关编码折线的更多信息，请参阅<https://developers.google.com/maps/documentation/utilities/polylinealgorithm> <br/><br/>**警告：**这个领域仍然**实验**，并且可能会发生变化。将来可能会正式采用。 |
+| **shape_id**         | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 必需的       | 一        | 標識符Shape.必須不同於任何`shape_id`在 (CSV) 中定義GTFS .<br/><br/>**警告：**這個領域仍然**實驗**，並且可能會發生變化。將來可能會正式採用。 |
+| **encoded_polyline** | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | 必需的       | 一        | 的編碼折線表示Shape.此折線必須至少包含兩個點。有關編碼折線的更多信息，請參閱<https://developers.google.com/maps/documentation/utilities/polylinealgorithm> <br/><br/>**警告：**這個領域仍然**實驗**，並且可能會發生變化。將來可能會正式採用。 |

--- a/docs/schedule/best-practices.zh_TW.md
+++ b/docs/schedule/best-practices.zh_TW.md
@@ -3,61 +3,61 @@ search:
   exclude: true
 ---
   
-# GTFS Schedule 最佳实践
+# GTFS Schedule 最佳實踐
 
-这些是描述公共交通服务的推荐做法General Transit Feed Specification[(](../reference)GTFS [)](../reference) .这些实践都是从[GTFS](<#\<glossary variable=>)的经验中总结出来的[-最佳实践工作组">](<#\<glossary variable=>)GTFS [最佳实践工作组](<#\<glossary variable=>)成员和[PHP](<http://www.transitwiki.org/TransitWiki/index.\<glossary variable=>) [/Best_practices_for_creating_GTFS">应用程序特定](<http://www.transitwiki.org/TransitWiki/index.\<glossary variable=>)GTFS [实践建议](<http://www.transitwiki.org/TransitWiki/index.\<glossary variable=>)。
+這些是描述公共交通服務的推薦做法General Transit Feed Specification[(](../reference)GTFS [)](../reference) .這些實踐都是從[GTFS](<#\<glossary variable=>)的經驗中總結出來的[-最佳實踐工作組">](<#\<glossary variable=>)GTFS [最佳實踐工作組](<#\<glossary variable=>)成員和[PHP](<http://www.transitwiki.org/TransitWiki/index.\<glossary variable=>) [/Best_practices_for_creating_GTFS">應用程序特定](<http://www.transitwiki.org/TransitWiki/index.\<glossary variable=>)GTFS [實踐建議](<http://www.transitwiki.org/TransitWiki/index.\<glossary variable=>)。
 
-有关更多背景信息，请参阅[常见问题](#frequently-asked-questions-faq)。
+有關更多背景信息，請參閱[常見問題](#frequently-asked-questions-faq)。
 
-## 文件结构
+## 文件結構
 
-实践分为四个主要部分：
+實踐分為四個主要部分：
 
-* __[数据集发布和一般实践](#dataset-publishing-general-practices)：__这些实践与数据集的整体结构有关GTFS数据集和其中的方式GTFS数据集发布。
-* __[按文件组织的实践建议](#practice-recommendations-organized-by-file)：__建议按文件和字段组织GTFS便于将映射实践反馈给官方GTFS参考。
-* __[按案例组织的实践建议](#practice-recommendations-organized-by-case)：__对于特定案例，例如循环路线，可能需要在多个文件和字段中应用实践。此类建议合并在本节中。
+* __[數據集發布和一般實踐](#dataset-publishing-general-practices)：__這些實踐與數據集的整體結構有關GTFS數據集和其中的方式GTFS數據集發布。
+* __[按文件組織的實踐建議](#practice-recommendations-organized-by-file)：__建議按文件和字段組織GTFS便於將映射實踐反饋給官方GTFS參考。
+* __[按案例組織的實踐建議](#practice-recommendations-organized-by-case)：__對於特定案例，例如循環路線，可能需要在多個文件和字段中應用實踐。此類建議合併在本節中。
 
-## 数据集发布和一般实践
+## 數據集發布和一般實踐
 
-* 数据集应发布在公共的永久 URL 上，包括 zip 文件名。 （例如， [GTFS](<http://www.agency.org/\<glossary variable=>) [/](<http://www.agency.org/\<glossary variable=>)GTFS [.zip">www.agency.org/](<http://www.agency.org/\<glossary variable=>)GTFS [/](<http://www.agency.org/\<glossary variable=>)GTFS [.zip](<http://www.agency.org/\<glossary variable=>) )。理想情况下，URL 应该可以直接下载，无需登录即可访问文件，以方便使用软件应用程序进行下载。虽然建议（也是最常见的做法）GTFS数据集可公开下载，如果数据提供者确实需要控制对GTFS出于许可或其他原因，建议控制对GTFS使用 API 密钥的数据集，这将有助于自动下载。
-* GTFS数据以迭代形式发布，因此在稳定位置的单个文件始终包含运输机构（或多个机构）的最新官方服务描述。
-* 维护持久标识符（id 字段）stop_id ,route_id ， 和agency_id尽可能跨数据迭代。
-* 一GTFS数据集应包含当前和即将推出的服务（有时称为“合并”数据集）。 Google transitfeed 工具的[合并功能](https://github.com/google/transitfeed/wiki/Merge)可用于从两个不同的数据集创建合并数据集GTFS饲料。
-  * 随时发布GTFS数据集应至少在接下来的 7 天内有效，理想情况下，只要操作员确信Schedule将继续运营。
-  * 如果可能的话，GTFS数据集应至少涵盖接下来 30 天的服务。
-* 从提要中删除旧服务（过期日历）。
-* 如果服务修改将在 7 天或更短时间内生效，请通过[GTFS](<https://developers.google.com/transit/\<glossary variable=>)表达此服务更改[-](<https://developers.google.com/transit/\<glossary variable=>)Realtime[/">](<https://developers.google.com/transit/\<glossary variable=>)GTFS [-](<https://developers.google.com/transit/\<glossary variable=>)Realtime提要（服务建议或旅行更新）而不是静态的GTFS数据集。
-* 网络服务器托管GTFS数据应配置为正确报告文件修改日期（参见[HTTP/1.1 - Request for Comments 2616](https://tools.ietf.org/html/rfc2616#section-14.29) ，在第 14.29 节下）。
+* 數據集應發佈在公共的永久 URL 上，包括 zip 文件名。 （例如， [GTFS](<http://www.agency.org/\<glossary variable=>) [/](<http://www.agency.org/\<glossary variable=>)GTFS [.zip">www.agency.org/](<http://www.agency.org/\<glossary variable=>)GTFS [/](<http://www.agency.org/\<glossary variable=>)GTFS [.zip](<http://www.agency.org/\<glossary variable=>) )。理想情況下，URL 應該可以直接下載，無需登錄即可訪問文件，以方便使用軟件應用程序進行下載。雖然建議（也是最常見的做法）GTFS數據集可公開下載，如果數據提供者確實需要控制對GTFS出於許可或其他原因，建議控制對GTFS使用 API 密鑰的數據集，這將有助於自動下載。
+* GTFS數據以迭代形式發布，因此在穩定位置的單個文件始終包含運輸機構（或多個機構）的最新官方服務描述。
+* 維護持久標識符（id 字段）stop_id ,route_id ， 和agency_id盡可能跨數據迭代。
+* 一GTFS數據集應包含當前和即將推出的服務（有時稱為“合併”數據集）。 Google transitfeed 工具的[合併功能](https://github.com/google/transitfeed/wiki/Merge)可用於從兩個不同的數據集創建合併數據集GTFS飼料。
+  * 隨時發布GTFS數據集應至少在接下來的 7 天內有效，理想情況下，只要操作員確信Schedule將繼續運營。
+  * 如果可能的話，GTFS數據集應至少涵蓋接下來 30 天的服務。
+* 從提要中刪除舊服務（過期日曆）。
+* 如果服務修改將在 7 天或更短時間內生效，請通過[GTFS](<https://developers.google.com/transit/\<glossary variable=>)表達此服務更改[-](<https://developers.google.com/transit/\<glossary variable=>)Realtime[/">](<https://developers.google.com/transit/\<glossary variable=>)GTFS [-](<https://developers.google.com/transit/\<glossary variable=>)Realtime提要（服務建議或旅行更新）而不是靜態的GTFS數據集。
+* 網絡服務器託管GTFS數據應配置為正確報告文件修改日期（參見[HTTP/1.1 - Request for Comments 2616](https://tools.ietf.org/html/rfc2616#section-14.29) ，在第 14.29 節下）。
 
-## 按文件组织的练习建议
+## 按文件組織的練習建議
 
-本节显示按文件和字段组织的实践，与GTFS[参考](../reference)。
+本節顯示按文件和字段組織的實踐，與GTFS[參考](../reference)。
 
 ### 所有文件
 
-| 字段名称 | 推荐                                                                                                                                     |
+| 字段名稱 | 推薦                                                                                                                                     |
 | ---- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| 混合案例 | 所有面向客户的文本字符串（包括站点名称、路线名称和车头标志）都应使用混合大小写（而不是全部大写），遵循本地约定，以便在能够显示小写字符的显示器上将地名大写。                                                         |
+| 混合案例 | 所有面向客戶的文本字符串（包括站點名稱、路線名稱和車頭標誌）都應使用混合大小寫（而不是全部大寫），遵循本地約定，以便在能夠顯示小寫字符的顯示器上將地名大寫。 |
 |      | 例子：                                                                                                                                    |
-|      | 布莱顿丘吉尔广场                                                                                                                               |
-|      | 马恩河畔维利尔斯                                                                                                                               |
-|      | 市场街                                                                                                                                    |
-| 缩写   | 避免在整个提要中使用名称和其他文本的缩写（例如 St. 代表街道），除非使用其缩写名称（例如“JFK 机场”）来调用位置。缩写可能会影响屏幕阅读器软件和语音用户界面的可访问性。消费软件可以设计为可靠地将完整单词转换为缩写词以供显示，但从缩写词转换为完整单词更容易出错。 |
+|      | 布萊頓丘吉爾廣場                                                                                                                               |
+|      | 馬恩河畔維利爾斯                                                                                                                               |
+|      | 市場街                                                                                                                                    |
+| 縮寫   | 避免在整個提要中使用名稱和其他文本的縮寫（例如 St. 代表街道），除非使用其縮寫名稱（例如“JFK 機場”）來調用位置。縮寫可能會影響屏幕閱讀器軟件和語音用戶界面的可訪問性。消費軟件可以設計為可靠地將完整單詞轉換為縮寫詞以供顯示，但從縮寫詞轉換為完整單詞更容易出錯。 |
 
 ### agency.txt
 
-| 字段名称              | 推荐                                                                                                              |
+| 字段名稱              | 推薦                                                                                                              |
 | ----------------- | --------------------------------------------------------------------------------------------------------------- |
-| `agency_id`       | 应包括在内，即使提要中只有一个机构。 （另见建议包括`agency_id`在[`routes.txt`](#routestxt)和[`fare_attributes.txt`](#fare_attributestxt) ) |
-| `agency_phone`    | 除非不存在此类客户服务电话，否则应包括在内。                                                                                          |
-| `agency_email`    | 除非不存在此类客户服务电子邮件，否则应包括在内。                                                                                        |
-| `agency_fare_url` | 除非该机构完全免费，否则应包括在内。                                                                                              |
+| `agency_id`       | 應包括在內，即使提要中只有一個機構。 （另見建議包括`agency_id`在[`routes.txt`](#routestxt)和[`fare_attributes.txt`](#fare_attributestxt) ) |
+| `agency_phone`    | 除非不存在此類客戶服務電話，否則應包括在內。 |
+| `agency_email`    | 除非不存在此類客戶服務電子郵件，否則應包括在內。 |
+| `agency_fare_url` | 除非該機構完全免費，否則應包括在內。 |
 
 __例子：__
 
-* 巴士服务由几家小型巴士公司经营。但是有一个大机构负责调度和票务，并且从用户的角度负责公共汽车服务。一个大机构应该定义为提要中的机构。即使数据在内部由不同的小型公交运营商进行拆分，Feed 中也应该只定义一个机构。
+* 巴士服務由幾家小型巴士公司經營。但是有一個大機構負責調度和票務，並且從用戶的角度負責公共汽車服務。一個大機構應該定義為提要中的機構。即使數據在內部由不同的小型公交運營商進行拆分，Feed 中也應該只定義一個機構。
 
-* 提要提供商运行票务门户，但有不同的机构实际运营服务并且用户知道要负责。实际运营服务的机构应定义为提要中的机构。
+* 提要提供商運行票務門戶，但有不同的機構實際運營服務並且用戶知道要負責。實際運營服務的機構應定義為提要中的機構。
 
 
 ### stops.txt
@@ -65,35 +65,35 @@ __例子：__
 |字段名稱 |推薦 |
 | --- | --- |
 | `stop_name` |如果沒有發布的站點名稱，請在整個提要中遵循一致的站點命名約定。 | |
-| |默認情況下，`stop_name` 不應包含通用或冗餘詞，如“Station”或“Stop”，但允許一些極端情況。<ul><li>當它實際上是名稱的一部分時（聯合車站、中央車站<li>當`stop_name`過於籠統時（比如如果它是城市的名稱）。“車站”、“終點站”或其他詞使含義清晰。</ul> |
+| |默認情況下，`stop_name` 不應包含通用或冗餘詞，如“Station”或“Stop”，但允許一些極端情況。 <ul><li>當它實際上是名稱的一部分時（聯合車站、中央車站<li>當`stop_name`過於籠統時（比如如果它是城市的名稱）。“車站”、“終點站”或其他詞使含義清晰。</ul> |
 | `stop_lat` & `stop_lon` |停止位置應盡可能準確。與實際停止位置相比，停止位置的誤差應不超過 __4 米。 |
 | |停靠點應放置在非常靠近乘客上車的行人通行權處（即街道的正確一側）。 |
 | |如果在不同的數據饋送中共享停靠點位置（即兩個代理機構使用完全相同的停靠/登機設施），則通過對兩個停靠點使用完全相同的 `stop_lat` 和 `stop_lon` 來指示該停靠點是共享的。 |
-| `parent_station` & `location_type` |許多車站或航站樓有多個登機設施（根據模式，它們可能被稱為巴士站、站台、碼頭、登機口或其他術語）。在這種情況下，飼料生產者應描述車站、寄宿設施（也稱為兒童站）及其關係。 <ul><li>車站或終點站應定義為 `stops.txt` 中的記錄，`location_type = 1`。</li><li>每個登機設施應定義為停靠站，`location_type = 0 `。 `parent_station` 字段應引用登機設施所在車站的 `stop_id`。</li></ul> |
-| |在給車站和兒童站命名時，設置讓乘客容易識別的名稱，並能幫助乘客識別車站和上車設施（公交車站、站台、碼頭、登機口等）。<table class='example' ><thead><tr><th>母站名稱</th><th>子站名稱</th></tr></thead><tbody><tr><td>芝加哥聯合車站</td ><td>芝加哥聯合車站 19 號站台</td></tr><tr><td>舊金山渡輪大廈航站樓</td><td>舊金山渡輪大廈航站樓 E 門</td></tr> <tr><td>Downtown Transit Center</td><td>Downtown Transit Center Bay B</td></tr></tbody></table> |
+| `parent_station` & `location_type` |許多車站或航站樓有多個登機設施（根據模式，它們可能被稱為巴士站、站台、碼頭、登機口或其他術語）。在這種情況下，飼料生產者應描述車站、寄宿設施（也稱為兒童站）及其關係。 <ul><li>車站或終點站應定義為 `stops.txt` 中的記錄，`location_type = 1`。 </li><li>每個登機設施應定義為停靠站，`location_type = 0 `。 `parent_station` 字段應引用登機設施所在車站的 `stop_id`。 </li></ul> |
+| |在給車站和兒童站命名時，設置讓乘客容易識別的名稱，並能幫助乘客識別車站和上車設施（公交車站、站台、碼頭、登機口等）。 <table class='example' ><thead><tr><th>母站名稱</th><th>子站名稱</th></tr></thead><tbody><tr><td>芝加哥聯合車站</td ><td>芝加哥聯合車站 19 號站台</td></tr><tr><td>舊金山渡輪大廈航站樓</td><td>舊金山渡輪大廈航站樓 E 門</td></tr> <tr><td>Downtown Transit Center</td><td>Downtown Transit Center Bay B</td></tr></tbody></table> |
 
 ### routes.txt
 
 |字段名稱 |推薦 |
 | --- | --- |
 | `route_short_name` |如果有簡短的服務名稱，請包括 `route_short_name`。這應該是服務的常用乘客姓名，不超過 12 個字符。 |
-| `route_long_name` |來自規範參考的定義：<q>此名稱通常比 <code>route_short_name</code> 更具描述性，並且通常包括路線的目的地或停靠點。必須至少指定 <code>route_short_name</code> 或 <code>route_long_name</code> 之一，或者如果合適，可能同時指定兩者。如果路由沒有長名，請指定一個<code>route_short_name</code>並使用空字符串作為該字段的值。</q><br>長名類型示例如下：<table class='example'><thead><tr><th colspan='3'>主要行進路徑或走廊</th></tr><tr><th>路線名稱</th><th>表格</th><th>機構</th></tr></thead><tbody><tr><td><a href='https://www.sfmta.com/getting-around/transit/ routes-stops/n-judah'>“N”/“Judah”</a></td><td><code>route_short_name</code>/<br><code>route_long_name</code></td ><td><a href='https://www.sfmta.com/'>Muni</a>，舊金山</td></tr><tr><td><a href='https ://trimet.org/schedules/r006.htm'>“6”/“ML King Jr Blvd”</a></td><td><code>route_short_name</code>/<br><code> route_long_name</code></td><td><a href='https://trimet.org/'>TriMet</a>，俄勒岡州波特蘭市。</td></tr><tr><td><a href='http://www.ratp.fr/informer/pdf/orienter/f_plan.php?nompdf=m6'>“6”/“Nation - Étoile”</a></td><td><code>route_short_name</code>/<br><code>route_long_name</c ode></td><td><a href='http://www.ratp.fr/'>RATP</a>，在法國巴黎。</td></tr><tr><td> <a href='http://www.bvg.de/images/content/linienverlaeufe/LinienverlaufU2.pdf'>“U2”-“Pankow – Ruhleben”</a></td><td><code>route_short_name </code>-<br><code>route_long_name</code></td><td><a href='http://www.bvg.de/'>BVG</a>，德國柏林</td></tr></tbody></table><table class='example'><thead><tr><th>服務說明</th></tr></thead><tbody><tr><td><a href='https://128bc.org/schedules/rev-bus-hartwell-area/'>“哈特韋爾地區班車”</a></td></tr> </tbody></table>   
+| `route_long_name` |來自規範參考的定義：<q>此名稱通常比 <code>route_short_name</code> 更具描述性，並且通常包括路線的目的地或停靠點。必須至少指定 <code>route_short_name</code> 或 <code>route_long_name</code> 之一，或者如果合適，可能同時指定兩者。如果路由沒有長名，請指定一個<code>route_short_name</code>並使用空字符串作為該字段的值。 </q><br>長名類型示例如下：<table class='example'><thead><tr><th colspan='3'>主要行進路徑或走廊</th></tr><tr><th>路線名稱</th><th>表格</th><th>機構</th></tr></thead><tbody><tr><td><a href='https://www.sfmta.com/getting-around/transit/ routes-stops/n-judah'>“N”/“Judah”</a></td><td><code>route_short_name</code>/<br><code>route_long_name</code></td ><td><a href='https://www.sfmta.com/'>Muni</a>，舊金山</td></tr><tr><td><a href='https ://trimet.org/schedules/r006.htm'>“6”/“ML King Jr Blvd”</a></td><td><code>route_short_name</code>/<br><code> route_long_name</code></td><td><a href='https://trimet.org/'>TriMet</a>，俄勒岡州波特蘭市。 </td></tr><tr><td><a href='http://www.ratp.fr/informer/pdf/orienter/f_plan.php?nompdf=m6'>“6”/“Nation - Étoile”</a></td><td><code>route_short_name</code>/<br><code>route_long_name</c ode></td><td><a href='http://www.ratp.fr/'>RATP</a>，在法國巴黎。 </td></tr><tr><td> <a href='http://www.bvg.de/images/content/linienverlaeufe/LinienverlaufU2.pdf'>“U2”-“Pankow – Ruhleben”</a></td><td><code>route_short_name </code>-<br><code>route_long_name</code></td><td><a href='http://www.bvg.de/'>BVG</a>，德國柏林</td></tr></tbody></table><table class='example'><thead><tr><th>服務說明</th></tr></thead><tbody><tr><td><a href='https://128bc.org/schedules/rev-bus-hartwell-area/'>“哈特韋爾地區班車”</a></td></tr> </tbody></table>   
 | | `route_long_name` 不應包含 `route_short_name`。 |
 | |在填充 `route_long_name` 時包括完整的名稱，包括服務標識。示例：<table class='example'><thead><tr><th>服務標識</th><th>推薦</th><th>示例</th></tr></thead><tbody><tr><td>“MAX 輕軌”<br>俄勒岡州波特蘭市的 TriMet</td><td><code>route_long_name</code> 應包括品牌 (MAX) 和具體路線名稱</td><td>“MAX 紅線”“MAX 藍線”</td></tr><tr><td>“快速騎行”<br>新墨西哥州阿爾伯克基的 ABQ 騎行</td> <td><code>route_long_name</code> 應包含品牌（Rapid Ride）和具體路線名稱</td><td>“Rapid Ride Red Line”<br>“Rapid Ride Blue Line”</td ></tr></tbody></table>
-| `route_id` |給定命名路線上的所有行程都應引用相同的“route_id”。 <li>不應將路線的不同方向劃分為不同的 `route_id` 值。</li><li>不應將路線的不同運營跨度劃分為不同的 `route_id` 值。即不要在 `routes.txt` 中為“Downtown AM”和“Downtown PM”服務創建不同的記錄）。</li> |
+| `route_id` |給定命名路線上的所有行程都應引用相同的“route_id”。 <li>不應將路線的不同方向劃分為不同的 `route_id` 值。 </li><li>不應將路線的不同運營跨度劃分為不同的 `route_id` 值。即不要在 `routes.txt` 中為“Downtown AM”和“Downtown PM”服務創建不同的記錄）。 </li> |
 | |如果路由組包含明確命名的分支（例如 1A 和 1B），請按照路由 [branches](#branches) 案例中的建議來確定 `route_short_name` 和 `route_long_name`。 |
 | `route_color` & `route_text_color` |應與標牌、印刷和在線客戶信息一致（如果其他地方不存在，則不包括在內）。 |
 
 ### trips.txt
 
-* __參見循環路線的特殊情況：__ 循環路線是指行程在同一站點開始和結束的情況，而不是線性路線，後者有兩個不同的終點。環路路線必須按照具體做法進行描述。 [參見循環路線案例。](#loop-routes)
-* __請參閱套索路線的特殊情況：__ 套索路線是線性和循環幾何形狀的混合體，其中車輛僅在部分路線上循環行駛。套索路線必須按照具體做法進行描述。 [參見套索路線案例。](#lasso-routes)
+* __參見循環路線的特殊情況：__ 循環路線是指行程在同一站點開始和結束的情況，而不是線性路線，後者有兩個不同的終點。環路路線必須按照具體做法進行描述。 [參見循環路線案例。 ](#loop-routes)
+* __請參閱套索路線的特殊情況：__ 套索路線是線性和循環幾何形狀的混合體，其中車輛僅在部分路線上循環行駛。套索路線必須按照具體做法進行描述。 [參見套索路線案例。 ](#lasso-routes)
 
 |字段名稱 |推薦 |
 | --- | --- |
 | `trip_headsign` |不要在 `trip_headsign` 或 `stop_headsign` 字段中提供路線名稱（匹配 `route_short_name` 和 `route_long_name`）。 |
 | |應包含目的地、方向和/或車輛頭標上顯示的其他行程指定文本，可用於區分路線中的行程。與車輛上顯示的方向信息保持一致是確定 GTFS 數據集中提供的頭標的主要和壓倒一切的目標。只有在不損害這一主要目標的情況下，才應包括其他信息。如果頭標在旅途中發生變化，請用 `stop_times.stop_headsign` 覆蓋 `trip_headsign`。以下是針對一些可能情況的建議： |
-| | <table class="example"><thead><tr><th>路線說明</th><th>推薦</th></tr></thead><tbody><tr><td>2A. Destination-only</td><td>提供終點站目的地。例如“交通中心”、“波特蘭市中心”或“詹岑海灘”> </td></tr><tr><td>2B.帶航點的目的地</td><td>&lt;destination&gt;通過&lt;航點&gt; “通過查令十字街的海格特”。如果在車輛通過這些航點後航點從向乘客顯示的航標中刪除，請使用 <code>stop_times.stop_headsign</code> 設置更新的航標。> </td></tr><tr><td>2℃。帶有本地站點的區域地名</td><td>如果目的地城市或自治市內有多個站點，請在到達目的地城市後使用<code>stop_times.stop_headsign</code>。> </td></tr><tr><td>2D。僅方向</td><td>使用諸如“北行”、“入站”、“順時針”或類似方向等術語表示。></td></tr><tr><td>2E。方向與目的地</td><td>&lt;direction&gt;到&lt;終點站名稱&gt;例如“南行至聖何塞”></td></tr><tr><td>2F。帶有目的地和航路點的方向</td><td>&lt;direction&gt;通過&lt;航點&gt;到&lt;目的地&gt; （“北行經查令十字到海格特”）。></td></tr></tbody></table> |
+| | <table class="example"><thead><tr><th>路線說明</th><th>推薦</th></tr></thead><tbody><tr><td>2A. Destination-only</td><td>提供終點站目的地。例如“交通中心”、“波特蘭市中心”或“詹岑海灘”> </td></tr><tr><td>2B.帶航點的目的地</td><td>&lt;destination&gt;通過&lt;航點&gt; “通過查令十字街的海格特”。如果在車輛通過這些航點後航點從向乘客顯示的航標中刪除，請使用 <code>stop_times.stop_headsign</code> 設置更新的航標。 > </td></tr><tr><td>2℃。帶有本地站點的區域地名</td><td>如果目的地城市或自治市內有多個站點，請在到達目的地城市後使用<code>stop_times.stop_headsign</code>。 > </td></tr><tr><td>2D。僅方向</td><td>使用諸如“北行”、“入站”、“順時針”或類似方向等術語表示。 ></td></tr><tr><td>2E。方向與目的地</td><td>&lt;direction&gt;到&lt;終點站名稱&gt;例如“南行至聖何塞”></td></tr><tr><td>2F。帶有目的地和航路點的方向</td><td>&lt;direction&gt;通過&lt;航點&gt;到&lt;目的地&gt; （“北行經查令十字到海格特”）。 ></td></tr></tbody></table> |
 | |不要以“To”或“Towards”作為頭標的開頭。 |
 | `direction_id` |在整個數據集中始終使用值 0 和 1。即<ul><li>如果 1 = 紅色路線上的出站，那麼 1 = 綠色路線上的出站</li><li>如果 1 = 路線 X 上的北行，那麼 1 = 路線 Y 上的北行</li> <li>如果 1 = 路線 X 順時針，則 1 = 路線 Y 順時針</li></ul> |
 
@@ -106,7 +106,7 @@ __例子：__
 | `pickup_type` & `drop_off_type` |對於所有 `stop_times` 行，不提供客運服務的無收入（死角）旅行應標記為 `pickup_type` 和 `drop_off_type` 值為 `1`。
 | |在收費旅行中，用於監控運營績效的內部“時間點”以及乘客無法上車的其他地方（例如車庫）應標有“pickup_type = 1”（不提供接送服務）和“drop_off_type = 1”（不提供下車服務） . |
 | `arrival_time` & `departure_time` | `arrival_time` 和 `departure_time` 字段應盡可能指定時間值，包括時間點之間的非約束估計或插值時間。 |
-| `stop_headsign` |一般來說，headsign 的值也應該與車站的標誌相對應。<br><br>在以下情況下，“Southbound”會誤導客戶，因為它沒有用於車站標誌。
+| `stop_headsign` |一般來說，headsign 的值也應該與車站的標誌相對應。 <br><br>在以下情況下，“Southbound”會誤導客戶，因為它沒有用於車站標誌。
 | | <table class="example"><thead><tr><th colspan="2">在紐約，對於 2 南行：</th></tr><tr><th>對於 <code>stop_times .txt</code> 行：</th><th>使用 <code>stop_headsign</code> 值：</th></tr></thead><tbody><tr><td>直到曼哈頓到達</td><td><code>曼哈頓和布魯克林</code></td></tr><tr><td>直到到達市中心</td><td><code>市中心和布魯克林</code></td></tr><tr><td>直到到達布魯克林</td><td><code>布魯克林</code></td></tr><tr><td>一旦到達布魯克林</td><td><code>布魯克林（新地段大道）</code></td></tr></tbody></table> |
 | | <table class="example"><thead><tr><th colspan="2">在波士頓，紅線南行，Braintree 支線：</th></tr><tr><th >對於 <code>stop_times.txt</code> 行：</th><th>使用 <code>stop_headsign</code> 值：</th></tr></thead><tbody><tr> <td>直到到達市中心</td><td><code>進入布倫特里</code></td></tr><tr><td>一旦到達市中心</td><td><code>Braintree</code></td></tr><tr><td>市區後</td><td><code>出站到Braintree</code></td> </tr></tbody></table> |
 | `shape_dist_traveled` |必須為具有循環或內聯的路線提供“shape_dist_traveled”（車輛在一次行程中穿過或經過相同的路線部分）。請參閱 [`shapes.shape_dist_traveled`](#shapestxt) 建議。 |
@@ -121,7 +121,7 @@ __例子：__
 
 |字段名稱 |推薦 |
 | --- | --- |
-|所有領域 |包含一個 `calendar.service_name` 字段也可以增加 GTFS 的可讀性，儘管這在規範中沒有被採用。|
+|所有領域 |包含一個 `calendar.service_name` 字段也可以增加 GTFS 的可讀性，儘管這在規範中沒有被採用。 |
 
 ### fare_attributes.txt
 
@@ -145,7 +145,7 @@ __例子：__
 |所有領域 |理想情況下，對於共享的路線（即，在路線 1 和 2 在同一段道路或軌道上運行的情況下），路線的共享部分應該完全匹配。這有助於促進高質量的交通製圖。 <!-- (77) -->
 | |路線應遵循車輛行駛的通行權的中心線。如果沒有指定車道，這可能是街道的中心線，也可能是沿車輛移動方向行駛的道路一側的中心線。 <br><br>路線不應“鋸齒”到路邊停靠點、平台或登機位置。 |
 | `shape_dist_traveled` |如果路線包括循環或內聯（車輛在一次行程中穿越或經過同一路線部分），則必須在“shapes.txt”和“stop_times.txt”中提供。 <img src="https://raw.githubusercontent.com/MobilityData/GTFS_Schedule_Best-Practices/master/en/inlining.svg" width=200px style="display: block; margin-left: auto; margin-right: auto ;"><br>如果車輛在旅行過程中在點處回溯或穿過路線路線，<code>shape_dist_traveled</code> 很重要，以闡明 <code>shapes.txt 中的點部分</code> code> 與 <code>stop_times.txt</code> 中的記錄對應。 |
-| | `shape_dist_traveled` 字段允許機構準確指定 `stop_times.txt` 文件中的停靠點如何適合其各自的形狀。用於 `shape_dist_traveled` 字段的常用值是車輛行駛時到形狀起點的距離（想想類似於里程表讀數的東西）。 <li>路線路線（在 `shapes.txt` 中）應在行程服務的停靠點 100 米範圍內。</li><li>簡化路線，以便 <code>shapes.txt</code> 不包含多餘的點（即刪除直線段上的多餘點；請參閱線簡化問題的討論）。</li>
+| | `shape_dist_traveled` 字段允許機構準確指定 `stop_times.txt` 文件中的停靠點如何適合其各自的形狀。用於 `shape_dist_traveled` 字段的常用值是車輛行駛時到形狀起點的距離（想想類似於里程表讀數的東西）。 <li>路線路線（在 `shapes.txt` 中）應在行程服務的停靠點 100 米範圍內。 </li><li>簡化路線，以便 <code>shapes.txt</code> 不包含多餘的點（即刪除直線段上的多餘點；請參閱線簡化問題的討論）。 </li>
 
 ### frequencies.txt
 
@@ -160,10 +160,10 @@ __例子：__
 
 |字段名稱 |推薦 |
 | --- | --- |
-| `transfer_type` | <q>0 或（空）：這是路線之間的推薦換乘點。</q><br>如果有多個換乘機會，包括一個更好的選擇（即具有額外便利設施的中轉中心或具有相鄰或連接的登機設施/平台），指定推薦的換乘點。 |
-| | <q>1：這是兩條路線之間的定時換乘點。出發的車輛應該等待到達的車輛，有足夠的時間讓乘客在路線之間換乘。</q><br>這種換乘類型會覆蓋所需的間隔以可靠地進行換乘。例如，谷歌地圖假設乘客需要 3 分鐘才能安全換乘。其他應用程序可能會採用其他默認值。 |
-| | <q>2：此轉移需要在到達和離開之間的最短時間以確保連接。換乘所需時間由 <code>min_transfer_time</code> 指定。</q><br>如果有障礙物或其他因素會增加停靠站之間的行駛時間，請指定最短換乘時間。 |
-| | <q>3：在此位置的路線之間無法進行換乘。</q><br>如果由於物理障礙而無法進行換乘，或者由於難以穿越的道路或道路上的縫隙而使換乘變得不安全或複雜，請指定此值行人網絡。 |
+| `transfer_type` | <q>0 或（空）：這是路線之間的推薦換乘點。 </q><br>如果有多個換乘機會，包括一個更好的選擇（即具有額外便利設施的中轉中心或具有相鄰或連接的登機設施/平台），指定推薦的換乘點。 |
+| | <q>1：這是兩條路線之間的定時換乘點。出發的車輛應該等待到達的車輛，有足夠的時間讓乘客在路線之間換乘。 </q><br>這種換乘類型會覆蓋所需的間隔以可靠地進行換乘。例如，谷歌地圖假設乘客需要 3 分鐘才能安全換乘。其他應用程序可能會採用其他默認值。 |
+| | <q>2：此轉移需要在到達和離開之間的最短時間以確保連接。換乘所需時間由 <code>min_transfer_time</code> 指定。 </q><br>如果有障礙物或其他因素會增加停靠站之間的行駛時間，請指定最短換乘時間。 |
+| | <q>3：在此位置的路線之間無法進行換乘。 </q><br>如果由於物理障礙而無法進行換乘，或者由於難以穿越的道路或道路上的縫隙而使換乘變得不安全或複雜，請指定此值行人網絡。 |
 | |如果行程之間允許進行座位內（塊）換乘，則到達行程的最後一站必須與出發行程的第一站相同。 |
 
 
@@ -203,7 +203,7 @@ __循環行程建模示例：__
 | trip_1  | 06:15:00     | 06:15:00       | stop_B  | 2             | "C"           |
 | trip_1  | 06:20:00     | 06:20:00       | stop_C  | 3             | "D"           |
 | trip_1  | 06:25:00     | 06:25:00       | stop_D  | 4             | "E"           |
-| trip_1  | 06:30:00     | 06:30:00       | stop_E  | 5             | "A"           |
+| trip_1  | 06:30:00     | 06:30:00       | stop_E| 5             | "A"           |
 | trip_1  | 06:35:00     | 06:35:00       | stop_A  | 6             | ""            |
  
 - 帶有兩個頭標的循環旅行
@@ -239,8 +239,8 @@ __循環行程建模示例：__
 
 |字段名稱 |推薦 |
 | --- | --- |
-| `trips.trip_id` | “車輛往返”的全部範圍（參見插圖 [上圖](#lasso-route-fig)）包括從 A 到 B 再到 B 並返回 A。整個車輛往返可以表示為：<li>`trips.txt`中的__single__`trip_id`值/記錄</li><li>`trips.txt`中的__Multiple__`trip_id`值/記錄，連續旅行由`block_id`指示。</li>李> |
-| `stop_times.stop_headsign` |沿 A-B 段的停靠點將雙向通過。 `stop_headsign` 便於區分行進方向。因此，建議為這些行程提供 `stop_headsign`。example_table: <table class="example"><thead> <tr><th>Examples:</th></tr></thead><tbody><tr ><td>“A 通過 B”</td></tr><tr><td>“A”</td></tr></tbody></table><table class="example"> <thead><tr><th>芝加哥交通局的<a href="http://www.transitchicago.com/purpleline/">紫線</a></th></tr></thead>< tbody><tr><td>“南行至環路”</td></tr><tr><td>“北行經環路”</td></tr><tr><td>“北行至林登"</td></tr></tbody></table><table class="example"><thead><tr><th>埃德蒙頓公交服務線路，此處<a href="http:// webdocs.edmonton.ca/transit/route_schedules_and_maps/future/RT039.pdf">39</a></th></tr></thead><tbody><tr><td>“盧瑟福”</td ></tr><tr><td>《世紀公園》</td></tr></tbody></table>
+| `trips.trip_id` | “車輛往返”的全部範圍（參見插圖 [上圖](#lasso-route-fig)）包括從 A 到 B 再到 B 並返回 A。整個車輛往返可以表示為：<li>`trips.txt`中的__single__`trip_id`值/記錄</li><li>`trips.txt`中的__Multiple__`trip_id`值/記錄，連續旅行由`block_id`指示。 </li>李> |
+| `stop_times.stop_headsign` |沿 A-B 段的停靠點將雙向通過。 `stop_headsign` 便於區分行進方向。因此，建議為這些行程提供 `stop_headsign`。 example_table: <table class="example"><thead> <tr><th>Examples:</th></tr></thead><tbody><tr ><td>“A 通過 B”</td></tr><tr><td>“A”</td></tr></tbody></table><table class="example"> <thead><tr><th>芝加哥交通局的<a href="http://www.transitchicago.com/purpleline/">紫線</a></th></tr></thead>< tbody><tr><td>“南行至環路”</td></tr><tr><td>“北行經環路”</td></tr><tr><td>“北行至林登"</td></tr></tbody></table><table class="example"><thead><tr><th>埃德蒙頓公交服務線路，此處<a href="http:// webdocs.edmonton.ca/transit/route_schedules_and_maps/future/RT039.pdf">39</a></th></tr></thead><tbody><tr><td>“盧瑟福”</td ></tr><tr><td>《世紀公園》</td></tr></tbody></table>
 | `trip.trip_headsign` |旅行頭標應該是旅行的全局描述，如時間表中顯示的那樣。可以是“Linden to Linden via Loop”（芝加哥示例），或“A to A via B”（通用示例）。 |
 
 ### 分支
@@ -252,7 +252,7 @@ __循環行程建模示例：__
 |字段名稱 |推薦 |
 | --- | --- |
 |所有領域 |在命名支線時，建議遵循其他旅客信息資料。以下是兩種情況的描述和示例： |
-| |如果時間表和路標表示兩條明確命名的路線（例如 1A 和 1B），則使用“route_short_name”和/或“route_long_name”字段在 GTFS 中顯示。示例：GoDurham Transit [路線 2、2A 和 2B](https://gotriangle.org/sites/default/files/brochure/godurham-route2-2a-2b_1.pdf) 在大部分路線中共享一個共同路線，但它們在幾個不同的方面有所不同。 <ul><li>Route 2 是核心服務，大部分時間運行。</li><li>Route 2 包括 Main Street 晚上、週日和節假日的偏離。</li><li>Route 2A 和 2B 運營週一至週六的白天時間。</li><li>路線 2B 在偏離共享路線的路線提供額外停靠點。</li></ul> |
+| |如果時間表和路標表示兩條明確命名的路線（例如 1A 和 1B），則使用“route_short_name”和/或“route_long_name”字段在 GTFS 中顯示。示例：GoDurham Transit [路線 2、2A 和 2B](https://gotriangle.org/sites/default/files/brochure/godurham-route2-2a-2b_1.pdf) 在大部分路線中共享一個共同路線，但它們在幾個不同的方面有所不同。 <ul><li>Route 2 是核心服務，大部分時間運行。 </li><li>Route 2 包括 Main Street 晚上、週日和節假日的偏離。 </li><li>Route 2A 和 2B 運營週一至週六的白天時間。 </li><li>路線 2B 在偏離共享路線的路線提供額外停靠點。 </li></ul> |
 | |如果機構提供的信息將分支描述為同名路線，則使用“trips.trip_headsign”、“stop_times.stop_headsign”和/或“trips.trip_short_name”字段。示例：GoTriangle [route 300](https://gotriangle.org/sites/default/files/route_300_v.1.19.pdf) 根據一天中的時間前往不同的位置。在通勤高峰時段，標準路線上增加了額外的支路，以容納進出城市的工人。 |
 
 ## 常見問題 (FAQ)

--- a/docs/schedule/index.zh_TW.md
+++ b/docs/schedule/index.zh_TW.md
@@ -15,10 +15,10 @@ search:
 
 要創建 GTFS 提要，請按照以下步驟操作。
 
-1. 创建所有需要的文件GTFSSchedule参考。如果需要其功能，请创建可选文件。
-1. 以 .txt 格式保存所有文件。字段值应以逗号分隔，并且每行应以换行符结尾。见GTFS有关文件内容的详细信息的参考。
-1. 将所有文本文件压缩在一起。压缩文件包含一个版本的提要。
-1. 使用以下选项之一发布提要。
+1. 創建所有需要的文件GTFSSchedule參考。如果需要其功能，請創建可選文件。
+1. 以 .txt 格式保存所有文件。字段值應以逗號分隔，並且每行應以換行符結尾。見GTFS有關文件內容的詳細信息的參考。
+1. 將所有文本文件壓縮在一起。壓縮文件包含一個版本的提要。
+1. 使用以下選項之一發布提要。
 
 ## 公開提供公交信息
 <hr>
@@ -27,23 +27,23 @@ search:
 
 託管 GTFS 數據的 Web 服務器應配置為正確報告文件修改日期（參見 HTTP/1.1 - Request for Comments 2616，第 14.29 節）。
 
-有关进一步的建议，请参阅“[最佳实践：数据集发布](best-practices/#dataset-publishing-general-practices)”。
+有關進一步的建議，請參閱“[最佳實踐：數據集發布](best-practices/#dataset-publishing-general-practices)”。
 
 
 ## 訓練
 <hr>
 
-世界银行开放学习园区 (OLC) 提供名为“ [GTFS](<https://olc.worldbank.org/content/introduction-general-transit-feed-specification-\<glossary variable=>) ”的基于自我的在线课程[-and-informal-transit-system-mapping">介绍](<https://olc.worldbank.org/content/introduction-general-transit-feed-specification-\<glossary variable=>)General Transit Feed Specification[(](<https://olc.worldbank.org/content/introduction-general-transit-feed-specification-\<glossary variable=>)GTFS [) 和非正式交通系统映射](<https://olc.worldbank.org/content/introduction-general-transit-feed-specification-\<glossary variable=>)”。本课程包括以下部分：
+世界銀行開放學習園區 (OLC) 提供名為“ [GTFS](<https://olc.worldbank.org/content/introduction-general-transit-feed-specification-\<glossary variable=>) ”的基於自我的在線課程[-and-informal-transit-system-mapping">介紹](<https://olc.worldbank.org/content/introduction-general-transit-feed-specification-\<glossary variable=>)General Transit Feed Specification[(](<https://olc.worldbank.org/content/introduction-general-transit-feed-specification-\<glossary variable=>)GTFS [) 和非正式交通系統映射](<https://olc.worldbank.org/content/introduction-general-transit-feed-specification-\<glossary variable=>)”。本課程包括以下部分：
 
 
-- 什么是GTFS ?历史和文件结构
-- 什么是GTFS ?可视化与社区
-- 设置一个GTFS喂养
-- GitHub 和开源工具简介
+- 什麼是GTFS ?歷史和文件結構
+- 什麼是GTFS ?可視化與社區
+- 設置一個GTFS餵養
+- GitHub 和開源工具簡介
 - 田野故事
-- 如何映射公交数据
-- 如何为城市的第一个 Feed 收集数据
-- 应用调查
+- 如何映射公交數據
+- 如何為城市的第一個 Feed 收集數據
+- 應用調查
 - GTFS -Realtime
 
 
@@ -56,11 +56,11 @@ search:
 
 當您對公共交通數據、軟件、GTFS 和 GTFS-realtime 等格式以及其他問題有疑問時，有許多郵件列表可能是很好的資源：
 
-* [GTFS Changes](https://groups.google.com/group/gtfs-changes): 讨论扩展 GTFS 规范的提案，如[GTFS 更改文档](https://github.com/google/transit/blob/master/gtfs/CHANGES.md)中所述
-* [GTFS Realtime](https://groups.google.com/group/gtfs-realtime): 讨论[GTFS 实时规范](https://github.com/google/transit/tree/master/gtfs-realtime)。
-* [MobilityData Slack](https://mobilitydata-io.slack.com/): Slack“组织”在专门讨论 GTFS 主题的频道。[在此处请求mobilitydata-io.slack.com 的邀请](https://share.mobilitydata.org/slack)。
-* [transitfeed](https://groups.google.com/group/transitfeed): 讨论开源[transitfeed](https://groups.google.com/group/transitfeed)项目，以及讨论GTFS规范和相关工具。
-* [transit-developers](https://groups.google.com/group/transit-developers): 一般运输开发商讨论。许多交通机构也有自己的专门针对该机构的开发者邮件列表。例如：
+* [GTFS Changes](https://groups.google.com/group/gtfs-changes): 討論擴展 GTFS 規範的提案，如[GTFS 更改文檔](https://github.com/google/transit/blob/master/gtfs/CHANGES.md)中所述
+* [GTFS Realtime](https://groups.google.com/group/gtfs-realtime): 討論[GTFS 實時規範](https://github.com/google/transit/tree/master/gtfs-realtime)。
+* [MobilityData Slack](https://mobilitydata-io.slack.com/): Slack“組織”在專門討論 GTFS 主題的頻道。 [在此處請求mobilitydata-io.slack.com 的邀請](https://share.mobilitydata.org/slack)。
+* [transitfeed](https://groups.google.com/group/transitfeed): 討論開源[transitfeed](https://groups.google.com/group/transitfeed)項目，以及討論GTFS規範和相關工具。
+* [transit-developers](https://groups.google.com/group/transit-developers): 一般運輸開發商討論。許多交通機構也有自己的專門針對該機構的開發者郵件列表。例如：
     * [NYC MTA](https://groups.google.com/group/mtadeveloperresources)
     * [Portland, OR](https://groups.google.com/group/transit-developers-pdx)
     * [BART - San Francisco, CA](https://groups.google.com/group/bart-developers)

--- a/docs/schedule/reference.zh_TW.md
+++ b/docs/schedule/reference.zh_TW.md
@@ -5,7 +5,7 @@ search:
   
 # GTFS Schedule 參考
 
-**2022 年 5 月 9 日修訂。有關詳細信息，請參閱 [Revision History](../revision-history)。**
+**2022 年 5 月 9 日修訂。有關詳細信息，請參閱 [Revision History](../revision-history)。 **
 
 本文檔定義了構成 GTFS 數據集的文件的格式和結構。
 
@@ -50,197 +50,197 @@ search:
 * **記錄** - 由多個不同字段值組成的基本數據結構，用於描述單個實體（例如公交代理、停靠站、路線等）。在表格中表示為一行。
 * **Field** - 對像或實體的屬性。在表中表示為一列。
 * **字段值** - 字段中的單個條目。在表格中表示為單個單元格。
-* **服務日** - 服務日是用於指示路線調度的時間段。服務日的確切定義因機構而異，但服務日通常與日曆日不一致。如果服務在一天開始並在第二天結束，則服務日可能會超過 24:00:00。例如，從周五 08:00:00 到週六 02:00:00 運行的服務可以表示為在單個服務日從 08:00:00 到 26:00:00 運行。
+* **服務日** - 服務日是用於指示路線調度的時間段。服務日的確切定義因機構而異，但服務日通常與日曆日不一致。如果服務在一天開始並在第二天結束，則服務日可能會超過 24:00:00。例如，從週五 08:00:00 到週六 02:00:00 運行的服務可以表示為在單個服務日從 08:00:00 到 26:00:00 運行。
 * **文本轉語音字段** - 該字段應包含與其父字段相同的信息（如果為空則回退）。它旨在被解讀為文本轉語音，因此，應該刪除縮寫（“St”應該讀作“Street”或“Saint”；“Elizabeth I”應該讀作“Elizabeth the first”）或保持原樣閱讀（“肯尼迪機場”被縮寫）。
 * **Leg** - 騎手在旅途中的兩個後續位置之間上下車的行程。
 * **旅程** - 從始發地到目的地的總體旅行，包括所有航段和中轉。
 * **子旅程** - 構成旅程子集的兩條或更多航段。
 * **票價產品** - 可用於支付或驗證旅行的可購買票價產品。
 
-### 在场
+### 在場
 
-适用于字段和文件的存在条件：
+適用於字段和文件的存在條件：
 
-* **必需**- 字段或文件必须包含在数据集中并包含每条记录的有效值。
-* **可选**- 可以从数据集中省略字段或文件。
-* **有条件地要求**- 字段或文件必须包含在字段或文件描述中概述的条件下。
-* **有条件禁止**- 字段或文件不得包含在字段或文件描述中概述的条件下。
+* **必需**- 字段或文件必須包含在數據集中並包含每條記錄的有效值。
+* **可選**- 可以從數據集中省略字段或文件。
+* **有條件地要求**- 字段或文件必須包含在字段或文件描述中概述的條件下。
+* **有條件禁止**- 字段或文件不得包含在字段或文件描述中概述的條件下。
 
-### 字段类型
+### 字段類型
 
-- **颜色**- 编码为六位十六进制数字的颜色。请参阅<https://htmlcolorcodes.com>以生成有效值（不得包含前导“#”）。<br/>*示例： `FFFFFF`表示白色， `000000`表示黑色或`0039A6`表示 NYMTA 中的 A、C、E 线。*<br/>
-- **货币代码**- ISO 4217 字母货币代码。有关当前货币列表，请参阅<https://en.wikipedia.org/wiki/ISO_4217#Active_codes> 。<br/>*示例： `CAD`代表加元， `EUR`代表欧元， `JPY`代表日元。*<br/>
-- **货币金额**- 表示货币金额的十进制值。 [ISO 4217](https://en.wikipedia.org/wiki/ISO\_4217#Active_codes)为随附的货币代码指定了小数位数。根据编程，所有财务计算都应以十进制、货币或其他适合财务计算的等效类型处理language用于消费数据。由于计算过程中的货币收益或损失，不鼓励将货币金额作为浮动来处理。
-- **日期**- YYYYMMDD 格式的服务日期。由于服务日内的时间可能高于 24:00:00，因此服务日可能包含后续日的信息。<br/>*示例： `20180913`表示 2018 年 9 月 13 日。*<br/>
-- **电子邮件**- 电子邮件地址。<br/>*示例： `example@example.com`*<br/>
-- **枚举**- “描述”列中定义的一组预定义常量中的一个选项。<br/>*示例： `route_type`字段包含`0`表示电车， `1`表示地铁......*<br/>
-- **ID** - ID 字段值是一个内部 ID，不打算向乘客显示，并且是任何 UTF-8 字符的序列。建议仅使用可打印的 ASCII 字符。当 ID 在文件中必须是唯一的时，它被标记为“唯一 ID”。在一个 .txt 文件中定义的 ID 通常在另一个 .txt 文件中被引用。引用另一个表中的 ID 的 ID 被标记为“外部 ID”。<br/>*示例：*stop_id*字段*stops.txt*是一个“唯一标识”。 `parent_station`字段在*stops.txt*是一个“外国ID参考`stops. stop_id`*stop_id *”。*<br/>
-- language**代码**- IETF BCP 47language代码。有关 IETF BCP 47 的介绍，请参阅<http://www.rfc-editor.org/rfc/bcp/bcp47.txt>和[语言](<http://www.w3.org/International/articles/\<glossary variable=>)[-tags/">http://www.w3.org/International/articles/](<http://www.w3.org/International/articles/\<glossary variable=>)language[-标签/](<http://www.w3.org/International/articles/\<glossary variable=>) 。<br/>*示例： `en`表示英语， `en-US`表示美式英语或`de`表示德语。*<br/>
-- **纬度**- WGS84 纬度，十进制度。该值必须大于或等于 -90.0 且小于或等于 90.0。*<br/>示例：罗马斗兽场的`41.890169` 。<br/>*
-- **经度**- WGS84 经度（十进制度）。该值必须大于或等于 -180.0 且小于或等于 180.0。<br/>*示例：罗马斗兽场的`12.492269` 。*<br/>
-- **Float** - 一个浮点数。
-- **整数**- 一个整数。
-- **电话号码**- 电话号码。
-- **Time** - HH:MM:SS 格式的时间（也接受 H:MM:SS）。时间从服务日的“中午减去 12 小时”开始计算（实际上是午夜，夏令时更改发生的日子除外）。对于发生在午夜之后的时间，请以大于 24:00:00 的值输入时间，以旅行当天的 HH:MM:SS 本地时间Schedule开始。<br/>*示例：第二天下午 2:30 为 14:30:00 或`25:35:00` `14:30:00`*<br/>
-- **文本**- 一个 UTF-8 字符串，旨在显示，因此必须是人类可读的。
-- **时区**- 来自<https://www.iana.org/time-zones>的 TZ 时区。时区名称从不包含空格字符，但可能包含下划线。有关有效值的列表，请参阅<http://en.wikipedia.org/wiki/List_of_tz_zones> 。<br/>*示例： `Asia/Tokyo` 、 `America/Los_Angeles`或`Africa/Cairo` 。*<br/>
-- **URL** - 包含 http\:// 或 https\:// 的完全限定 URL，并且 URL 中的任何特殊字符都必须正确转义。有关如何创建完全限定 URL 值的说明，请参阅以下<http://www.w3.org/Addressing/URL/4_URI_Recommentations.html> 。
+- **顏色**- 編碼為六位十六進制數字的顏色。請參閱<https://htmlcolorcodes.com>以生成有效值（不得包含前導“#”）。 <br/>*示例： `FFFFFF`表示白色， `000000`表示黑色或`0039A6`表示 NYMTA 中的 A、C、E 線。 *<br/>
+- **貨幣代碼**- ISO 4217 字母貨幣代碼。有關當前貨幣列表，請參閱<https://en.wikipedia.org/wiki/ISO_4217#Active_codes> 。 <br/>*示例： `CAD`代表加元， `EUR`代表歐元， `JPY`代表日元。 *<br/>
+- **貨幣金額**- 表示貨幣金額的十進制值。 [ISO 4217](https://en.wikipedia.org/wiki/ISO\_4217#Active_codes)為隨附的貨幣代碼指定了小數位數。根據編程，所有財務計算都應以十進制、貨幣或其他適合財務計算的等效類型處理language用於消費數據。由於計算過程中的貨幣收益或損失，不鼓勵將貨幣金額作為浮動來處理。
+- **日期**- YYYYMMDD 格式的服務日期。由於服務日內的時間可能高於 24:00:00，因此服務日可能包含後續日的信息。 <br/>*示例： `20180913`表示 2018 年 9 月 13 日。 *<br/>
+- **電子郵件**- 電子郵件地址。 <br/>*示例： `example@example.com`*<br/>
+- **枚舉**- “描述”列中定義的一組預定義常量中的一個選項。 <br/>*示例： `route_type`字段包含`0`表示電車， `1`表示地鐵......*<br/>
+- **ID** - ID 字段值是一個內部 ID，不打算向乘客顯示，並且是任何 UTF-8 字符的序列。建議僅使用可打印的 ASCII 字符。當 ID 在文件中必須是唯一的時，它被標記為“唯一 ID”。在一個 .txt 文件中定義的 ID 通常在另一個 .txt 文件中被引用。引用另一個表中的 ID 的 ID 被標記為“外部 ID”。 <br/>*示例：*stop_id*字段*stops.txt*是一個“唯一標識”。 `parent_station`字段在*stops.txt*是一個“外國ID參考`stops. stop_id`*stop_id *”。 *<br/>
+- language**代碼**- IETF BCP 47language代碼。有關 IETF BCP 47 的介紹，請參閱<http://www.rfc-editor.org/rfc/bcp/bcp47.txt>和[語言](<http://www.w3.org/International/articles/\<glossary variable=>)[-tags/">http://www.w3.org/International/articles/](<http://www.w3.org/International/articles/\<glossary variable=>)language[-標籤/](<http://www.w3.org/International/articles/\<glossary variable=>) 。<br/>*示例： `en`表示英語， `en-US`表示美式英語或`de`表示德語。*<br/>
+- **緯度**- WGS84 緯度，十進制度。該值必須大於或等於 -90.0 且小於或等於 90.0。 *<br/>示例：羅馬鬥獸場的`41.890169` 。 <br/>*
+- **經度**- WGS84 經度（十進制度）。該值必須大於或等於 -180.0 且小於或等於 180.0。 <br/>*示例：羅馬鬥獸場的`12.492269` 。 *<br/>
+- **Float** - 一個浮點數。
+- **整數**- 一個整數。
+- **電話號碼**- 電話號碼。
+- **Time** - HH:MM:SS 格式的時間（也接受 H:MM:SS）。時間從服務日的“中午減去 12 小時”開始計算（實際上是午夜，夏令時更改發生的日子除外）。對於發生在午夜之後的時間，請以大於 24:00:00 的值輸入時間，以旅行當天的 HH:MM:SS 本地時間Schedule開始。 <br/>*示例：第二天下午 2:30 為 14:30:00 或`25:35:00` `14:30:00`*<br/>
+- **文本**- 一個 UTF-8 字符串，旨在顯示，因此必須是人類可讀的。
+- **時區**- 來自<https://www.iana.org/time-zones>的 TZ 時區。時區名稱從不包含空格字符，但可能包含下劃線。有關有效值的列表，請參閱<http://en.wikipedia.org/wiki/List_of_tz_zones> 。 <br/>*示例： `Asia/Tokyo` 、 `America/Los_Angeles`或`Africa/Cairo` 。 *<br/>
+- **URL** - 包含 http\:// 或 https\:// 的完全限定 URL，並且 URL 中的任何特殊字符都必須正確轉義。有關如何創建完全限定 URL 值的說明，請參閱以下<http://www.w3.org/Addressing/URL/4_URI_Recommentations.html> 。
 
-### 现场标志
+### 現場標誌
 
-适用于浮点或整数字段类型的符号：
+適用於浮點或整數字段類型的符號：
 
-- **非负数**- 大于或等于 0。
-- **非零**- 不等于 0。
-- **正**- 大于 0。
+- **非負數**- 大於或等於 0。
+- **非零**- 不等於 0。
+- **正**- 大於 0。
 
-*示例：**非负浮点数**- 大于或等于 0 的浮点数。*
+*示例：**非負浮點數**- 大於或等於 0 的浮點數。 *
 
-### 数据集属性
+### 數據集屬性
 
-数据集的**主键**是唯一标识行的字段或字段组合。当文件的所有提供字段都用于唯一标识行时，使用`Primary key (*)` 。 `Primary key (none)`表示文件只允许一行。
+數據集的**主鍵**是唯一標識行的字段或字段組合。當文件的所有提供字段都用於唯一標識行時，使用`Primary key (*)` 。 `Primary key (none)`表示文件只允許一行。
 
-*示例：*trip_id*和*stop_sequence*字段作为主键*stop_times.txt *.*
+*示例：*trip_id*和*stop_sequence*字段作為主鍵*stop_times.txt *.*
 
-## 数据集文件
+## 數據集文件
 
-本规范定义了以下文件：
+本規範定義了以下文件：
 
-| 文件名                                                | 在场        | 描述                                                                                                                                                                                                                                                                                   |
+| 文件名                                                | 在場        | 描述|
 | -------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [agency.txt](#agencytxt)                           | **必需的**   | 在此数据集中提供服务的交通机构。                                                                                                                                                                                                                                                                     |
-| [stops.txt](#stopstxt)                             | **必需的**   | 在车辆接送乘客的地方停靠。还定义了车站和车站入口。                                                                                                                                                                                                                                                            |
-| [routes.txt](#routestxt)                           | **必需的**   | 过境路线。路线是作为单一服务向乘客显示的一组行程。                                                                                                                                                                                                                                                            |
-| [trips.txt](#tripstxt)                             | **必需的**   | 每条路线的行程。行程是在特定时间段内发生的两个或多个停靠点的序列。                                                                                                                                                                                                                                                    |
-| [stop_times.txt](#stop_timestxt)                   | **必需的**   | 每次行程中车辆到达和离开站点的时间。                                                                                                                                                                                                                                                                   |
-| [calendar.txt](#calendartxt)                       | **有条件要求** | 使用每周指定的服务日期Schedule带有开始和结束日期。<br/><br/>有条件要求：<br/>-**必需的**除非所有服务日期都在[calendar_dates.txt](#calendar_datestxt) .<br/> - 否则可选。                                                                                                                                                          |
-| [calendar_dates.txt](#calendar_datestxt)           | **有条件要求** | 中定义的服务的例外情况[calendar.txt](#calendartxt) .<br/><br/>有条件要求：<br/> -**必需的**如果[calendar.txt](#calendartxt)被省略。在这种情况下[calendar_dates.txt](#calendar_datestxt)必须包含所有服务日期。<br/> - 否则可选。                                                                                                      |
-| [fare_attributes.txt](#fare_attributestxt)         | 可选的       | 公交公司路线的票价信息。                                                                                                                                                                                                                                                                         |
-| [fare_rules.txt](#fare_rulestxt)                   | **有条件要求** | 为行程应用票价的规则。<br/><br/>有条件要求：<br/> -**必需的**如果[fare_attributes.txt](#fare_attributestxt)被定义为。<br/> -**禁止的**否则。                                                                                                                                                                          |
-| [fare_products.txt](#fare_productstxt)             | 可选的       | 描述乘客可以购买的不同类型的车票或票价。<br/><br/>文件[fare_products.txt](fare_productstxt)描述未在[fare_attributes.txt](#fare_attributestxt)和[fare_rules.txt](#fare_rulestxt).因此，使用[fare_products.txt](#fare_productstxt)与文件完全分开[fare_attributes.txt](#fare_attributestxt)和[fare_rules.txt](#fare_rulestxt) . |
-| [fare_leg_rules.txt](#fare_leg_rulestxt)           | 可选的       | 单程旅行的票价规则。<br/><br/>文件[fare_leg_rules.txt](#fare_leg_rulestxt)为票价结构建模提供了更详细的方法。因此，使用[fare_leg_rules.txt](#fare_leg_rulestxt)与文件完全分开[fare_attributes.txt](#fare_attributestxt)和[fare_rules.txt](#fare_rulestxt) .                                                                     |
-| [fare_transfer_rules.txt](#fare_transfer_rulestxt) | 可选的       | 旅行航段之间换乘的票价规则。<br/><br/>随着[fare_leg_rules.txt](#fare_leg_rulestxt)， 文件[fare_transfer_rules.txt](#fare_transfer_rulestxt)为票价结构建模提供了更详细的方法。因此，使用[fare_transfer_rules.txt](#fare_transfer_rulestxt)与文件完全分开[fare_attributes.txt](#fare_attributestxt)和[fare_rules.txt](#fare_rulestxt) . |
-| [areas.txt](areastxt)                              | 可选的       | 位置的区域分组。                                                                                                                                                                                                                                                                             |
-| [stop_areas.txt](stop_areastxt)                    | 可选的       | 为区域分配停靠点的规则。                                                                                                                                                                                                                                                                         |
-| [shapes.txt](#shapestxt)                           | 可选的       | 映射车辆行驶路径的规则，有时称为路线路线。                                                                                                                                                                                                                                                                |
-| [frequencies.txt](#frequenciestxt)                 | 可选的       | 基于车距的服务的车距（行程之间的时间）或固定的压缩表示Schedule服务。                                                                                                                                                                                                                                               |
-| [transfers.txt](#transferstxt)                     | 可选的       | 在路线之间的换乘点建立连接的规则。                                                                                                                                                                                                                                                                    |
-| [pathways.txt](#pathwaystxt)                       | 可选的       | 连接车站内位置的路径。                                                                                                                                                                                                                                                                          |
-| [levels.txt](#levelstxt)                           | **有条件要求** | 车站内的水平。<br/><br/>有条件要求：<br/> -**必需的**当描述有电梯的路径时（`pathway_mode=5` ）。 <br/> - 否则可选。                                                                                                                                                                                                    |
-| [translations.txt](#translationstxt)               | 可选的       | 面向客户的数据集值的翻译。                                                                                                                                                                                                                                                                        |
-| [feed_info.txt](#feed_infotxt)                     | 可选的       | 数据集元数据，包括发布者、版本和到期信息。                                                                                                                                                                                                                                                                |
-| [attributions.txt](#attributionstxt)               | 可选的       | 数据集属性。                                                                                                                                                                                                                                                                               |
+| [agency.txt](#agencytxt)                           | **必需的**   | 在此數據集中提供服務的交通機構。 |
+| [stops.txt](#stopstxt)                             | **必需的**   | 在車輛接送乘客的地方停靠。還定義了車站和車站入口。 |
+| [routes.txt](#routestxt)                           | **必需的**   | 過境路線。路線是作為單一服務向乘客顯示的一組行程。 |
+| [trips.txt](#tripstxt)                             | **必需的**   | 每條路線的行程。行程是在特定時間段內發生的兩個或多個停靠點的序列。 |
+| [stop_times.txt](#stop_timestxt)                   | **必需的**   | 每次行程中車輛到達和離開站點的時間。 |
+| [calendar.txt](#calendartxt)                       | **有條件要求** | 使用每週指定的服務日期Schedule帶有開始和結束日期。 <br/><br/>有條件要求：<br/>-**必需的**除非所有服務日期都在[calendar_dates.txt](#calendar_datestxt) .<br/> - 否則可選。 |
+| [calendar_dates.txt](#calendar_datestxt)           | **有條件要求** | 中定義的服務的例外情況[calendar.txt](#calendartxt) .<br/><br/>有條件要求：<br/> -**必需的**如果[calendar.txt](#calendartxt)被省略。在這種情況下[calendar_dates.txt](#calendar_datestxt)必須包含所有服務日期。 <br/> - 否則可選。 |
+| [fare_attributes.txt](#fare_attributestxt)         | 可選的       | 公交公司路線的票價信息。 |
+| [fare_rules.txt](#fare_rulestxt)                   | **有條件要求** | 為行程應用票價的規則。 <br/><br/>有條件要求：<br/> -**必需的**如果[fare_attributes.txt](#fare_attributestxt)被定義為。 <br/> -**禁止的**否則。 |
+| [fare_products.txt](#fare_productstxt)             | 可選的       | 描述乘客可以購買的不同類型的車票或票價。 <br/><br/>文件[fare_products.txt](fare_productstxt)描述未在[fare_attributes.txt](#fare_attributestxt)和[fare_rules.txt](#fare_rulestxt).因此，使用[fare_products.txt](#fare_productstxt)與文件完全分開[fare_attributes.txt](#fare_attributestxt)和[fare_rules.txt](#fare_rulestxt) . |
+| [fare_leg_rules.txt](#fare_leg_rulestxt)           | 可選的       | 單程旅行的票價規則。 <br/><br/>文件[fare_leg_rules.txt](#fare_leg_rulestxt)為票價結構建模提供了更詳細的方法。因此，使用[fare_leg_rules.txt](#fare_leg_rulestxt)與文件完全分開[fare_attributes.txt](#fare_attributestxt)和[fare_rules.txt](#fare_rulestxt) .                                                                     |
+| [fare_transfer_rules.txt](#fare_transfer_rulestxt) | 可選的       | 旅行航段之間換乘的票價規則。 <br/><br/>隨著[fare_leg_rules.txt](#fare_leg_rulestxt)， 文件[fare_transfer_rules.txt](#fare_transfer_rulestxt)為票價結構建模提供了更詳細的方法。因此，使用[fare_transfer_rules.txt](#fare_transfer_rulestxt)與文件完全分開[fare_attributes.txt](#fare_attributestxt)和[fare_rules.txt](#fare_rulestxt) . |
+| [areas.txt](areastxt)                              | 可選的       | 位置的區域分組。|
+| [stop_areas.txt](stop_areastxt)                    | 可選的       | 為區域分配停靠點的規則。 |
+| [shapes.txt](#shapestxt)                           | 可選的       | 映射車輛行駛路徑的規則，有時稱為路線路線。 |
+| [frequencies.txt](#frequenciestxt)                 | 可選的       | 基於車距的服務的車距（行程之間的時間）或固定的壓縮表示Schedule服務。 |
+| [transfers.txt](#transferstxt)                     | 可選的       | 在路線之間的換乘點建立連接的規則。 |
+| [pathways.txt](#pathwaystxt)                       | 可選的       | 連接車站內位置的路徑。 |
+| [levels.txt](#levelstxt)                           | **有條件要求** | 車站內的水平。 <br/><br/>有條件要求：<br/> -**必需的**當描述有電梯的路徑時（`pathway_mode=5` ）。 <br/> - 否則可選。 |
+| [translations.txt](#translationstxt)               | 可選的       | 面向客戶的數據集值的翻譯。 |
+| [feed_info.txt](#feed_infotxt)                     | 可選的       | 數據集元數據，包括發布者、版本和到期信息。 |
+| [attributions.txt](#attributionstxt)               | 可選的       | 數據集屬性。 |
 
 
 ## 文件要求
 
-以下要求适用于数据集文件的格式和内容：
+以下要求適用於數據集文件的格式和內容：
 
-* 所有文件都必须保存为逗号分隔的文本。
-* 每个文件的第一行必须包含字段名称。[字段定义](#field-definitions)部分的每个子部分对应于一个文件中的一个GTFS数据集并列出该文件中可能使用的字段名称。
-* 所有文件名和字段名都区分大小写。
-* 字段值不得包含制表符、回车符或换行符。
-* 包含引号或逗号的字段值必须用引号引起来。此外，字段值中的每个引号前面都必须有一个引号。这与 Microsoft Excel 输出逗号分隔 (CSV) 文件的方式一致。有关 CSV 文件格式的更多信息，请参阅<http://tools.ietf.org/html/rfc4180> 。
+* 所有文件都必須保存為逗號分隔的文本。
+* 每個文件的第一行必須包含字段名稱。 [字段定義](#field-definitions)部分的每個子部分對應於一個文件中的一個GTFS數據集並列出該文件中可能使用的字段名稱。
+* 所有文件名和字段名都區分大小寫。
+* 字段值不得包含製表符、回車符或換行符。
+* 包含引號或逗號的字段值必須用引號引起來。此外，字段值中的每個引號前面都必須有一個引號。這與 Microsoft Excel 輸出逗號分隔 (CSV) 文件的方式一致。有關 CSV 文件格式的更多信息，請參閱<http://tools.ietf.org/html/rfc4180> 。
 
-以下示例演示了字段值在逗号分隔文件中的显示方式：
+以下示例演示了字段值在逗號分隔文件中的顯示方式：
 
 * **原始字段值：** `Contains "quotes", commas and text`
 * **CSV 文件中的字段值：** `"Contains ""quotes"", commas and text"`
-* 字段值不得包含 HTML 标记、注释或转义序列。
-* 应删除字段或字段名称之间的多余空格。许多解析器认为空格是值的一部分，这可能会导致错误。
-* 每行必须以 CRLF 或 LF 换行符结尾。
-* 文件应以 UTF-8 编码以支持所有 Unicode 字符。包含 Unicode 字节顺序标记 (BOM) 字符的文件是可接受的。有关 BOM 字符和 UTF-8 的更多信息，请参见<http://unicode.org/faq/utf_bom.html#BOM> 。
-* 所有数据集文件必须压缩在一起。
+* 字段值不得包含 HTML 標記、註釋或轉義序列。
+* 應刪除字段或字段名稱之間的多餘空格。許多解析器認為空格是值的一部分，這可能會導致錯誤。
+* 每行必須以 CRLF 或 LF 換行符結尾。
+* 文件應以 UTF-8 編碼以支持所有 Unicode 字符。包含 Unicode 字節順序標記 (BOM) 字符的文件是可接受的。有關 BOM 字符和 UTF-8 的更多信息，請參見<http://unicode.org/faq/utf_bom.html#BOM> 。
+* 所有數據集文件必須壓縮在一起。
 
-## 字段定义
+## 字段定義
 
 ### agency.txt
 
 文件：**必填**
 
-首要的关键 （agency_id )
+首要的關鍵 （agency_id )
 
-| 字段名称              | 类型         | 在场        | 描述                                                                                                                                                            |
+| 字段名稱              | 類型         | 在場        | 描述                                                                                                                                                            |
 | ----------------- | ---------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `agency_id`       | 唯一身份       | **有条件要求** | 标识通常与运输机构同义的运输品牌。请注意，在某些情况下，例如当一个代理机构运营多个单独的服务时，代理机构和品牌是不同的。本文档使用术语“代理”代替“品牌”。一个数据集可能包含来自多个机构的数据。<br/><br/>有条件要求：<br/> -**必需的**当数据集包含多个交通机构的数据时。<br/> - 否则可选。 |
-| `agency_name`     | 文本         | **必需的**   | 运输机构的全称。                                                                                                                                                      |
-| `agency_url`      | 网址         | **必需的**   | 公交机构的网址。                                                                                                                                                      |
-| `agency_timezone` | 时区         | **必需的**   | 运输机构所在的时区。如果在数据集中指定了多个机构，每个机构必须具有相同的`agency_timezone` .                                                                                                       |
-| `agency_lang`     | language代码 | 可选的       | 基本的language由该运输机构使用。应提供帮助GTFS消费者选择大小写规则等language- 数据集的特定设置。                                                                                                   |
-| `agency_phone`    | 电话号码       | 可选的       | 指定机构的语音电话号码。此字段是一个字符串值，表示该机构服务区域的典型电话号码。它可能包含标点符号来对数字的数字进行分组。允许使用可拨号文本（例如，TriMet 的“503-238-RIDE”），但该字段不得包含任何其他描述性文本。                                          |
-| `agency_fare_url` | 网址         | 可选的       | 允许乘客在线为该机构购买车票或其他票价工具的网页的 URL。                                                                                                                                |
-| `agency_email`    | 电子邮件       | 可选的       | 由该机构的客户服务部门积极监控的电子邮件地址。此电子邮件地址应该是一个直接联系点，公交乘客可以联系到该机构的客户服务代表。                                                                                                 |
+| `agency_id`       | 唯一身份       | **有條件要求** | 標識通常與運輸機構同義的運輸品牌。請注意，在某些情況下，例如當一個代理機構運營多個單獨的服務時，代理機構和品牌是不同的。本文檔使用術語“代理”代替“品牌”。一個數據集可能包含來自多個機構的數據。 <br/><br/>有條件要求：<br/> -**必需的**當數據集包含多個交通機構的數據時。 <br/> - 否則可選。 |
+| `agency_name`     | 文本         | **必需的**   | 運輸機構的全稱。 |
+| `agency_url`      | 網址         | **必需的**   | 公交機構的網址。 |
+| `agency_timezone` | 時區         | **必需的**   | 運輸機構所在的時區。如果在數據集中指定了多個機構，每個機構必須具有相同的`agency_timezone` .                                                                                                       |
+| `agency_lang`     | language代碼 | 可選的       | 基本的language由該運輸機構使用。應提供幫助GTFS消費者選擇大小寫規則等language- 數據集的特定設置。 |
+| `agency_phone`    | 電話號碼       | 可選的       | 指定機構的語音電話號碼。此字段是一個字符串值，表示該機構服務區域的典型電話號碼。它可能包含標點符號來對數字的數字進行分組。允許使用可撥號文本（例如，TriMet 的“503-238-RIDE”），但該字段不得包含任何其他描述性文本。 |
+| `agency_fare_url` | 網址         | 可選的       | 允許乘客在線為該機構購買車票或其他票價工具的網頁的 URL。 |
+| `agency_email`    | 電子郵件       | 可選的       | 由該機構的客戶服務部門積極監控的電子郵件地址。此電子郵件地址應該是一個直接聯繫點，公交乘客可以聯繫到該機構的客戶服務代表。 |
 
 ### stops.txt
 
 文件：**必填**
 
-首要的关键 （stop_id )
+首要的關鍵 （stop_id )
 
-| 字段名称                  | 类型                       | 在场        | 描述                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| 字段名稱                  | 類型                       | 在場        | 描述                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | --------------------- | ------------------------ | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `stop_id`             | 唯一身份                     | **必需的**   | 识别位置：站台/站台、车站、入口/出口、通用节点或登机区（见`location_type`）。<br/><br/>多条路线可以使用相同的`stop_id` .                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| `stop_code`           | 文本                       | 可选的       | 标识乘客位置的短文本或数字。这些代码通常用于基于电话的交通信息系统或印在标牌上，以使乘客更容易获得特定位置的信息。这`stop_code`可能与`stop_id`如果它是面向公众的。对于没有向乘客提供代码的位置，此字段应留空。                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| `stop_name`           | 文本                       | **有条件要求** | 位置的名称。这`stop_name`应与打印在时间表上、在线发布或出现在标牌上的机构面向骑手的位置名称相匹配。要翻译成其他语言，请使用`translations.txt` .<br/><br/>当位置是登机区时（`location_type=4` ）， 这`stop_name`应包含机构显示的登机区名称。它可能只是一个字母（如一些欧洲城际火车站），也可能是“Wheelchair boarding area”（纽约市的地铁）或“短途列车负责人”（巴黎的 RER）之类的文字。<br/><br/>有条件要求：<br/> -**必需的**对于停靠点（`location_type=0` ), 车站 (`location_type=1` ) 或入口/出口 (`location_type=2` ）。 <br/> - 对于通用节点的位置是可选的（`location_type=3` ) 或登机区 (`location_type=4` ）。                                                                                                             |
-| `tts_stop_name`       | 文本                       | 可选的       | 的可读版本`stop_name` .请参阅“文本转语音字段”中的[术语定义](#term-definitions)更多。                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| `stop_desc`           | 文本                       | 可选的       | 提供有用的优质信息的位置描述。不应重复`stop_name` .                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| `stop_lat`            | 纬度                       | **有条件要求** | 位置的纬度。<br/><br/>对于停靠点/平台（`location_type=0` ) 和登机区 (`location_type=4` )，坐标必须是公共汽车杆的坐标（如果存在），否则是旅行者上车的位置（在人行道或平台上，而不是在车辆停靠的道路或轨道上）。<br/><br/>有条件要求：<br/> -**必需的**对于停靠点（`location_type=0` ), 车站 (`location_type=1` ) 或入口/出口 (`location_type=2` ）。 <br/> - 对于通用节点的位置是可选的（`location_type=3` ) 或登机区 (`location_type=4` ）。                                                                                                                                                                                                                          |
-| `stop_lon`            | 经度                       | **有条件要求** | 位置的经度。<br/><br/>对于停靠点/平台（`location_type=0` ) 和登机区 (`location_type=4` )，坐标必须是公共汽车杆的坐标（如果存在），否则是旅行者上车的位置（在人行道或平台上，而不是在车辆停靠的道路或轨道上）。<br/><br/>有条件要求：<br/> -**必需的**对于停靠点（`location_type=0` ), 车站 (`location_type=1` ) 或入口/出口 (`location_type=2` ）。 <br/> - 对于通用节点的位置是可选的（`location_type=3` ) 或登机区 (`location_type=4` ）。                                                                                                                                                                                                                          |
-| `zone_id`             | ID                       | **有条件要求** | 标识停靠的票价区。如果该记录代表车站或车站入口，则`zone_id`被忽略。<br/><br/>有条件要求：<br/> -**必需的**如果使用提供票价信息[fare_rules.txt](#fare_rulestxt) <br/> - 否则可选。                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| `stop_url`            | 网址                       | 可选的       | 有关该位置的网页的 URL。这应该不同于`agency.agency_url`和`routes.route_url`字段值。                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| `location_type`       | 枚举                       | 可选的       | 位置类型。有效的选项是：<br/><br/>`0` （或空白）-**停止** （或者**平台**）。乘客上车或下车的地方。当定义在一个`parent_station` .<br/>`1` -**车站**.包含一个或多个平台的物理结构或区域。<br/>`2` -**入口/出口**.乘客可以从街道进出车站的位置。如果一个入口/出口属于多个站点，它可能通过路径链接到两个站点，但数据提供者必须选择其中一个作为父站点。<br/>`3` -**通用节点**.车站内的位置，不匹配任何其他位置`location_type`，可用于将定义的路径链接在一起pathways.txt .<br/>`4` -**登机区**.平台上的特定位置，乘客可以在此上下车。                                                                                                                                                                                                           |
-| `parent_station`      | 国外身份证参考`stops.stop_id`   | **有条件要求** | 定义中定义的不同位置之间的层次结构`stops.txt`.它包含父位置的 ID，如下所示：<br/><br/> -**停止/平台**(`location_type=0`）： 这`parent_station`字段包含站的 ID。<br/> -**车站** (`location_type=1` )：此字段必须为空。<br/> -**入口/出口** (`location_type=2` ） 或者**通用节点** (`location_type=3`）： 这`parent_station`字段包含站的 ID (`location_type=1` )<br/> -**登机区** (`location_type=4`）： 这`parent_station`字段包含平台的 ID。<br/><br/>有条件要求：<br/> -**必需的**对于作为入口的位置（`location_type=2` ), 通用节点 (`location_type=3` ) 或登机区 (`location_type=4` ）。 <br/> - 可选停靠站/平台（`location_type=0` ）。 <br/> - 禁止车站（`location_type=1` ）。  |
-| `stop_timezone`       | 时区                       | 可选的       | 位置的时区。如果该位置有父站，它将继承父站的时区，而不是应用自己的时区。车站和无父母的车站空车`stop_timezone`继承指定的时区`agency.agency_timezone`.如果`stop_timezone`提供的值，在时间[stop_times.txt](#stop_timetxt)应输入自指定时区午夜以来的时间`agency.agency_timezone`.这可确保旅行中的时间值始终在旅行过程中增加，无论旅行跨越哪个时区。                                                                                                                                                                                                                                                                                                              |
-| `wheelchair_boarding` | 枚举                       | 可选的       | 指示是否可以从该位置搭乘轮椅。有效的选项是：<br/><br/>对于无父母站点：<br/>`0`或为空 - 没有该站点的可访问性信息。<br/>`1` - 此站的部分车辆可由坐轮椅的骑手上车。<br/>`2` - 此站无法使用轮椅登机。<br/><br/>对于子站：<br/>`0`或为空 - Stop 将继承其`wheelchair_boarding`来自父站的行为，如果在父站中指定。<br/>`1` - 从车站外到特定车站/平台存在一些可访问的路径。<br/>`2` - 没有从车站外到特定车站/站台的无障碍路径。<br/><br/>车站出入口：<br/>`0`或为空 - 车站入口将继承其`wheelchair_boarding`如果为父站指定，则来自父站的行为。<br/>`1` - 车站入口可供轮椅通行。<br/>`2` - 从车站入口到车站/站台没有无障碍通道。                                                                                                                                         |
-| `level_id`            | 国外身份证参考`levels.level_id` | 可选的       | 位置的级别。多个未链接的站点可以使用同一级别。                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| `platform_code`       | 文本                       | 可选的       | 站台站台的站台标识符（属于站台的站台）。这应该只是平台标识符（例如“G”或“3”）。诸如“平台”或“轨道”之类的词（或提要的language- 特定等价物）不应包括在内。这使提要消费者能够更轻松地将平台标识符国际化和本地化为其他语言。                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `stop_id`             | 唯一身份                     | **必需的**   | 識別位置：站台/站台、車站、入口/出口、通用節點或登機區（見`location_type`）。 <br/><br/>多條路線可以使用相同的`stop_id` .                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `stop_code`           | 文本                       | 可選的       | 標識乘客位置的短文本或數字。這些代碼通常用於基於電話的交通信息系統或印在標牌上，以使乘客更容易獲得特定位置的信息。這`stop_code`可能與`stop_id`如果它是面向公眾的。對於沒有向乘客提供代碼的位置，此字段應留空。 |
+| `stop_name`           | 文本                       | **有條件要求** | 位置的名稱。這`stop_name`應與打印在時間表上、在線發布或出現在標牌上的機構面向騎手的位置名稱相匹配。要翻譯成其他語言，請使用`translations.txt` .<br/><br/>當位置是登機區時（`location_type=4` ）， 這`stop_name`應包含機構顯示的登機區名稱。它可能只是一個字母（如一些歐洲城際火車站），也可能是“Wheelchair boarding area”（紐約市的地鐵）或“短途列車負責人”（巴黎的 RER）之類的文字。 <br/><br/>有條件要求：<br/> -**必需的**對於停靠點（`location_type=0` ), 車站 (`location_type=1` ) 或入口/出口 (`location_type=2` ）。 <br/> - 對於通用節點的位置是可選的（`location_type=3` ) 或登機區 (`location_type=4` ）。 |
+| `tts_stop_name`       | 文本                       | 可選的       | 的可讀版本`stop_name` .請參閱“文本轉語音字段”中的[術語定義](#term-definitions)更多。 |
+| `stop_desc`           | 文本                       | 可選的       | 提供有用的優質信息的位置描述。不應重複`stop_name` .|
+| `stop_lat`            | 緯度                       | **有條件要求** | 位置的緯度。 <br/><br/>對於停靠點/平台（`location_type=0` ) 和登機區 (`location_type=4` )，坐標必須是公共汽車桿的坐標（如果存在），否則是旅行者上車的位置（在人行道或平台上，而不是在車輛停靠的道路或軌道上）。 <br/><br/>有條件要求：<br/> -**必需的**對於停靠點（`location_type=0` ), 車站 (`location_type=1` ) 或入口/出口 (`location_type=2` ）。 <br/> - 對於通用節點的位置是可選的（`location_type=3` ) 或登機區 (`location_type=4` ）。 |
+| `stop_lon`            | 經度                       | **有條件要求** | 位置的經度。 <br/><br/>對於停靠點/平台（`location_type=0` ) 和登機區 (`location_type=4` )，坐標必須是公共汽車桿的坐標（如果存在），否則是旅行者上車的位置（在人行道或平台上，而不是在車輛停靠的道路或軌道上）。 <br/><br/>有條件要求：<br/> -**必需的**對於停靠點（`location_type=0` ), 車站 (`location_type=1` ) 或入口/出口 (`location_type=2` ）。 <br/> - 對於通用節點的位置是可選的（`location_type=3` ) 或登機區 (`location_type=4` ）。 |
+| `zone_id`             | ID                       | **有條件要求** | 標識停靠的票價區。如果該記錄代表車站或車站入口，則`zone_id`被忽略。 <br/><br/>有條件要求：<br/> -**必需的**如果使用提供票價信息[fare_rules.txt](#fare_rulestxt) <br/> - 否則可選。 |
+| `stop_url`            | 網址                       | 可選的       | 有關該位置的網頁的 URL。這應該不同於`agency.agency_url`和`routes.route_url`字段值。 |
+| `location_type`       | 枚舉                       | 可選的       | 位置類型。有效的選項是：<br/><br/>`0` （或空白）-**停止** （或者**平台**）。乘客上車或下車的地方。當定義在一個`parent_station` .<br/>`1` -**車站**.包含一個或多個平台的物理結構或區域。 <br/>`2` -**入口/出口**.乘客可以從街道進出車站的位置。如果一個入口/出口屬於多個站點，它可能通過路徑鏈接到兩個站點，但數據提供者必須選擇其中一個作為父站點。 <br/>`3` -**通用節點**.車站內的位置，不匹配任何其他位置`location_type`，可用於將定義的路徑鏈接在一起pathways.txt .<br/>`4` -**登機區**.平台上的特定位置，乘客可以在此上下車。 |
+| `parent_station`      | 國外身份證參考`stops.stop_id`   | **有條件要求** | 定義中定義的不同位置之間的層次結構`stops.txt`.它包含父位置的 ID，如下所示：<br/><br/> -**停止/平台**(`location_type=0`）： 這`parent_station`字段包含站的 ID。 <br/> -**車站** (`location_type=1` )：此字段必須為空。 <br/> -**入口/出口** (`location_type=2` ） 或者**通用節點** (`location_type=3`）： 這`parent_station`字段包含站的 ID (`location_type=1` )<br/> -**登機區** (`location_type=4`）： 這`parent_station`字段包含平台的 ID。 <br/><br/>有條件要求：<br/> -**必需的**對於作為入口的位置（`location_type=2` ), 通用節點 (`location_type=3` ) 或登機區 (`location_type=4` ）。 <br/> - 可選停靠站/平台（`location_type=0` ）。 <br/> - 禁止車站（`location_type=1` ）。 |
+| `stop_timezone`       | 時區                       | 可選的       | 位置的時區。如果該位置有父站，它將繼承父站的時區，而不是應用自己的時區。車站和無父母的車站空車`stop_timezone`繼承指定的時區`agency.agency_timezone`.如果`stop_timezone`提供的值，在時間[stop_times.txt](#stop_timetxt)應輸入自指定時區午夜以來的時間`agency.agency_timezone`.這可確保旅行中的時間值始終在旅行過程中增加，無論旅行跨越哪個時區。 |
+| `wheelchair_boarding` | 枚舉                       | 可選的       | 指示是否可以從該位置搭乘輪椅。有效的選項是：<br/><br/>對於無父母站點：<br/>`0`或為空 - 沒有該站點的可訪問性信息。 <br/>`1` - 此站的部分車輛可由坐輪椅的騎手上車。 <br/>`2` - 此站無法使用輪椅登機。 <br/><br/>對於子站：<br/>`0`或為空 - Stop 將繼承其`wheelchair_boarding`來自父站的行為，如果在父站中指定。 <br/>`1` - 從車站外到特定車站/平台存在一些可訪問的路徑。 <br/>`2` - 沒有從車站外到特定車站/站台的無障礙路徑。 <br/><br/>車站出入口：<br/>`0`或為空 - 車站入口將繼承其`wheelchair_boarding`如果為父站指定，則來自父站的行為。 <br/>`1` - 車站入口可供輪椅通行。 <br/>`2` - 從車站入口到車站/站台沒有無障礙通道。 |
+| `level_id`            | 國外身份證參考`levels.level_id` | 可選的       | 位置的級別。多個未鏈接的站點可以使用同一級別。|
+| `platform_code`       | 文本                       | 可選的       | 站台站台的站台標識符（屬於站台的站台）。這應該只是平台標識符（例如“G”或“3”）。諸如“平台”或“軌道”之類的詞（或提要的language- 特定等價物）不應包括在內。這使提要消費者能夠更輕鬆地將平台標識符國際化和本地化為其他語言。 |
 
 ### routes.txt
 
 文件：**必填**
 
-首要的关键 （route_id )
+首要的關鍵 （route_id )
 
-| 字段名称                  | 类型                        | 在场        | 描述                                                                                                                                                                                                                                                                                                                                                                                              |
+| 字段名稱                  | 類型                        | 在場        | 描述                                                                                                                                                                                                                                                                                                                                                                                              |
 | --------------------- | ------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `route_id`            | 唯一身份                      | **必需的**   | 标识一条路线。                                                                                                                                                                                                                                                                                                                                                                                         |
-| `agency_id`           | 国外身份证参考`agency.agency_id` | **有条件要求** | 指定路线的代理。<br/><br/>有条件要求：<br/> -**必需的**如果定义了多个机构[agency.txt](#agency) .<br/> - 否则可选。                                                                                                                                                                                                                                                                                                             |
-| `route_short_name`    | 文本                        | **有条件要求** | 路线的简称。通常是一个简短的、抽象的标识符（例如，“32”、“100X”、“Green”），骑手用来识别路线。两个都`route_short_name`和`route_long_name`可以定义。<br/><br/>有条件要求：<br/> -**必需的**如果`routes.route_long_name`是空的。<br/> - 否则可选。                                                                                                                                                                                                                    |
-| `route_long_name`     | 文本                        | **有条件要求** | 路线的全名。此名称通常比`route_short_name`并且通常包括路线的目的地或站点。两个都`route_short_name`和`route_long_name`可以定义。<br/><br/>有条件要求：<br/> -**必需的**如果`routes.route_short_name`是空的。<br/> - 否则可选。                                                                                                                                                                                                                            |
-| `route_desc`          | 文本                        | 可选的       | 提供有用的优质信息的路线的描述。不应重复`route_short_name`或者`route_long_name` .<hr/> _示例：“A”号列车始终在曼哈顿 Inwood-207 St 和皇后区 Far Rockaway-Mott Avenue 之间运行。同样从早上 6 点到午夜，额外的“A”号列车在 Inwood-207 St 和 Lefferts Boulevard 之间运行（列车通常在 Lefferts Blvd 和 Far Rockaway 之间交替运行）。_                                                                                                                                                 |
-| `route_type`          | 枚举                        | **必需的**   | 指示路线上使用的交通工具类型。有效的选项是：<br/><br/>`0` - 有轨电车、有轨电车、轻轨。大都市区内的任何轻轨或街道系统。<br/>`1` - 地铁，地铁。大都市区内的任何地下铁路系统。<br/>`2` - 铁路。用于城际或长途旅行。<br/>`3` - 公共汽车。用于短途和长途巴士路线。<br/>`4` - 渡轮。用于短途和长途船服务。<br/>`5` - 缆车。用于电缆在车辆下方运行的街道轨道车（例如，旧金山的缆车）。<br/>`6` - 空中升降机、悬挂式缆车（例如缆车、空中缆车）。使用一根或多根电缆悬挂客舱、汽车、吊船或开放式椅子的电缆运输。<br/>`7` - 缆车。任何专为陡峭斜坡设计的轨道系统。<br/>`11` - 无轨电车。使用电线杆从架空电线中获取电力的电动巴士。<br/>`12` - 单轨电车。轨道由单轨或横梁组成的铁路。 |
-| `route_url`           | 网址                        | 可选的       | 关于特定路由的网页的 URL。应该不同于`agency.agency_url`价值。                                                                                                                                                                                                                                                                                                                                                      |
-| `route_color`         | 颜色                        | 可选的       | 与面向公众的材料相匹配的路线颜色指定。默认为白色（`FFFFFF` ) 当省略或留空时。之间的色差`route_color`和`route_text_color`在黑白屏幕上观看时应提供足够的对比度。                                                                                                                                                                                                                                                                                            |
-| `route_text_color`    | 颜色                        | 可选的       | 用于在背景上绘制的文本的清晰颜色`route_color`.默认为黑色（`000000`) 当省略或留空时。之间的色差`route_color`和`route_text_color`在黑白屏幕上观看时应提供足够的对比度。                                                                                                                                                                                                                                                                                  |
-| `route_sort_order`    | 非负整数                      | 可选的       | 以最适合向客户展示的方式对路线进行排序。较小的路线`route_sort_order`值应首先显示。                                                                                                                                                                                                                                                                                                                                              |
-| `continuous_pickup`   | 枚举                        | 可选的       | 表示骑手可以在车辆行驶路径上的任何点登上运输车辆，如`shapes.txt`，在路线的每次行程中。有效的选项是：<br/><br/>`0` - 连续停止皮卡。<br/>`1`或空 - 没有连续停止拾取。<br/>`2` - 必须打电话给代理安排连续停止取件。<br/>`3` - 必须与司机协调安排连续停车接送。<br/><br/>价值观`routes.continuous_pickup`可以通过在中定义值来覆盖`stop_times.continuous_pickup`对于特定的`stop_time`沿着路线。                                                                                                                              |
-| `continuous_drop_off` | 枚举                        | 可选的       | 表示骑手可以在车辆行驶路径上的任何点从运输车辆下车，如下所述`shapes.txt` ，在路线的每次行程中。有效的选项是：<br/><br/>`0`- 连续停止下降。<br/>`1`或空 - 没有连续停止下降。<br/>`2` - 必须打电话给代理商安排连续的中途下车。<br/>`3` - 必须与司机协调安排连续停车下车。<br/><br/>价值观`routes.continuous_drop_off`可以通过在中定义值来覆盖`stop_times.continuous_drop_off`对于特定的`stop_time`沿着路线。                                                                                                                    |
-| `network_id`          |  ID                       | 可选的       | 标识一组路由。中的多行[routes.txt](#routestxt)可能有相同的`network_id` .                                                                                                                                                                                                                                                                                                                                         |
+| `route_id`            | 唯一身份                      | **必需的**   | 標識一條路線。 |
+| `agency_id`           | 國外身份證參考`agency.agency_id` | **有條件要求** | 指定路線的代理。 <br/><br/>有條件要求：<br/> -**必需的**如果定義了多個機構[agency.txt](#agency) .<br/> - 否則可選。 |
+| `route_short_name`    | 文本                        | **有條件要求** | 路線的簡稱。通常是一個簡短的、抽象的標識符（例如，“32”、“100X”、“Green”），騎手用來識別路線。兩個都`route_short_name`和`route_long_name`可以定義。 <br/><br/>有條件要求：<br/> -**必需的**如果`routes.route_long_name`是空的。 <br/> - 否則可選。 |
+| `route_long_name`     | 文本                        | **有條件要求** | 路線的全名。此名稱通常比`route_short_name`並且通常包括路線的目的地或站點。兩個都`route_short_name`和`route_long_name`可以定義。 <br/><br/>有條件要求：<br/> -**必需的**如果`routes.route_short_name`是空的。 <br/> - 否則可選。 |
+| `route_desc`          | 文本                        | 可選的       | 提供有用的優質信息的路線的描述。不應重複`route_short_name`或者`route_long_name` .<hr/> _示例：“A”號列車始終在曼哈頓 Inwood-207 St 和皇后區 Far Rockaway-Mott Avenue 之間運行。同樣從早上 6 點到午夜，額外的“A”號列車在 Inwood-207 St 和 Lefferts Boulevard 之間運行（列車通常在 Lefferts Blvd 和 Far Rockaway 之間交替運行）。 _                                                                                                                                                 |
+| `route_type`          | 枚舉                        | **必需的**   | 指示路線上使用的交通工具類型。有效的選項是：<br/><br/>`0` - 有軌電車、有軌電車、輕軌。大都市區內的任何輕軌或街道系統。 <br/>`1` - 地鐵，地鐵。大都市區內的任何地下鐵路系統。 <br/>`2` - 鐵路。用於城際或長途旅行。 <br/>`3` - 公共汽車。用於短途和長途巴士路線。 <br/>`4` - 渡輪。用於短途和長途船服務。 <br/>`5` - 纜車。用於電纜在車輛下方運行的街道軌道車（例如，舊金山的纜車）。 <br/>`6` - 空中升降機、懸掛式纜車（例如纜車、空中纜車）。使用一根或多根電纜懸掛客艙、汽車、吊船或開放式椅子的電纜運輸。 <br/>`7` - 纜車。任何專為陡峭斜坡設計的軌道系統。 <br/>`11` - 無軌電車。使用電線桿從架空電線中獲取電力的電動巴士。 <br/>`12` - 單軌電車。軌道由單軌或橫梁組成的鐵路。 |
+| `route_url`           | 網址                        | 可選的       | 關於特定路由的網頁的 URL。應該不同於`agency.agency_url`價值。|
+| `route_color`         | 顏色                        | 可選的       | 與面向公眾的材料相匹配的路線顏色指定。默認為白色（`FFFFFF` ) 當省略或留空時。之間的色差`route_color`和`route_text_color`在黑白屏幕上觀看時應提供足夠的對比度。 |
+| `route_text_color`    | 顏色                        | 可選的       | 用於在背景上繪製的文本的清晰顏色`route_color`.默認為黑色（`000000`) 當省略或留空時。之間的色差`route_color`和`route_text_color`在黑白屏幕上觀看時應提供足夠的對比度。 |
+| `route_sort_order`    | 非負整數                      | 可選的       | 以最適合向客戶展示的方式對路線進行排序。較小的路線`route_sort_order`值應首先顯示。 |
+| `continuous_pickup`   | 枚舉                        | 可選的       | 表示騎手可以在車輛行駛路徑上的任何點登上運輸車輛，如`shapes.txt`，在路線的每次行程中。有效的選項是：<br/><br/>`0` - 連續停止皮卡。 <br/>`1`或空 - 沒有連續停止拾取。 <br/>`2` - 必須打電話給代理安排連續停止取件。 <br/>`3` - 必須與司機協調安排連續停車接送。 <br/><br/>價值觀`routes.continuous_pickup`可以通過在中定義值來覆蓋`stop_times.continuous_pickup`對於特定的`stop_time`沿著路線。 |
+| `continuous_drop_off` | 枚舉                        | 可選的       | 表示騎手可以在車輛行駛路徑上的任何點從運輸車輛下車，如下所述`shapes.txt` ，在路線的每次行程中。有效的選項是：<br/><br/>`0`- 連續停止下降。 <br/>`1`或空 - 沒有連續停止下降。 <br/>`2` - 必須打電話給代理商安排連續的中途下車。 <br/>`3` - 必須與司機協調安排連續停車下車。 <br/><br/>價值觀`routes.continuous_drop_off`可以通過在中定義值來覆蓋`stop_times.continuous_drop_off`對於特定的`stop_time`沿著路線。 |
+| `network_id`          |  ID                       | 可選的       | 標識一組路由。中的多行[routes.txt](#routestxt)可能有相同的`network_id` .                                                                                                                                                                                                                                                                                                                                         |
 
 
 ### trips.txt
 
 文件：**必填**
 
-首要的关键 （trip_id )
+首要的關鍵 （trip_id )
 
-| 字段名称                    | 类型                                                        | 在场        | 描述                                                                                                                                                                                                                                                                                                                                    |
+| 字段名稱                    | 類型                                                        | 在場        | 描述                                                                                                                                                                                                                                                                                                                                    |
 | ----------------------- | --------------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `route_id`              | 国外身份证参考`routes.route_id`                                  | **必需的**   | 标识一条路线。                                                                                                                                                                                                                                                                                                                               |
-| `service_id`            | 国外身份证参考`calendar.service_id`或者`calendar_dates.service_id` | **必需的**   | 确定服务可用于一条或多条路线的一组日期。                                                                                                                                                                                                                                                                                                                  |
-| `trip_id`               | 唯一身份                                                      | **必需的**   | 标识行程。                                                                                                                                                                                                                                                                                                                                 |
-| `trip_headsign`         | 文本                                                        | 可选的       | 出现在标牌上的文字，用于向乘客指明行程的目的地。应该用于区分同一路由上的不同服务模式。<br/><br/>如果头标在旅途中发生变化，则值为`trip_headsign`可以通过在中定义值来覆盖`stop_times.stop_headsign`对于特定的`stop_time`在旅途中。                                                                                                                                                                                       |
-| `trip_short_name`       | 文本                                                        | 可选的       | 用于识别乘客行程的面向公众的文本，例如，识别通勤铁路旅行的火车号码。如果乘客通常不依赖行程名称，`trip_short_name`应该是空的。一个`trip_short_name`值（如果提供）应唯一标识服务日内的行程；它不应用于目的地名称或有限/明确指定。                                                                                                                                                                                                     |
-| `direction_id`          | 枚举                                                        | 可选的       | 指示旅行的行进方向。该字段不应在路由中使用；它提供了一种在发布时间表时按方向分隔行程的方法。有效的选项是：<br/><br/>`0` - 单向旅行（例如出境旅行）。<br/>`1` - 向相反方向行驶（例如入境旅行）。<hr/>*示例：`trip_headsign`和`direction_id`字段可以一起使用，为一组行程分配一个名称，以在每个方向上行驶。一个[trips.txt](#tripstxt)文件可以包含这些记录以在时间表中使用：* <br/> `trip_id,...,trip_headsign,direction_id` <br/> `1234,...,Airport,0` <br/> `1505,...,Downtown,1` |
-| `block_id`              |  ID                                                       | 可选的       | 标识行程所属的块。一个区块由使用同一车辆的单次行程或多次连续行程组成，由共享服务天数和`block_id`.一个`block_id`可能有不同服务天数的行程，形成不同的区块。见[下面的例子](#example-blocks-and-service-day).提供座位转移信息，[转移](#transferstxt)的`transfer_type` `4`应改为提供。                                                                                                                                               |
-| `shape_id`              | 国外身份证参考`shapes.shape_id`                                  | **有条件要求** | 标识描述旅行的车辆行驶路径的地理空间形状。<br/><br/>有条件要求：<br/> -**必需的**如果行程具有连续接送或下车行为定义`routes.txt`或在`stop_times.txt` .<br/> - 否则可选。                                                                                                                                                                                                                     |
-| `wheelchair_accessible` | 枚举                                                        | 可选的       | 表示轮椅可及性。有效的选项是：<br/><br/>`0`或为空 - 没有行程的无障碍信息。<br/>`1` - 在此特定行程中使用的车辆可容纳至少一名坐在轮椅上的乘客。<br/>`2` - 此行程不接待坐轮椅的乘客。                                                                                                                                                                                                                          |
-| `bikes_allowed`         | 枚举                                                        | 可选的       | 指示是否允许骑自行车。有效的选项是：<br/><br/>`0`或为空 - 没有行程的自行车信息。<br/>`1` - 在这次特定旅行中使用的车辆可以容纳至少一辆自行车。<br/>`2` - 此行程不允许骑自行车。                                                                                                                                                                                                                            |
+| `route_id`              | 國外身份證參考`routes.route_id`                                  | **必需的**   | 標識一條路線。 |
+| `service_id`            | 國外身份證參考`calendar.service_id`或者`calendar_dates.service_id` | **必需的**   | 確定服務可用於一條或多條路線的一組日期。 |
+| `trip_id`               | 唯一身份                                                      | **必需的**   | 標識行程。|
+| `trip_headsign`         | 文本                                                        | 可選的       | 出現在標牌上的文字，用於向乘客指明行程的目的地。應該用於區分同一路由上的不同服務模式。 <br/><br/>如果頭標在旅途中發生變化，則值為`trip_headsign`可以通過在中定義值來覆蓋`stop_times.stop_headsign`對於特定的`stop_time`在旅途中。 |
+| `trip_short_name`       | 文本                                                        | 可選的       | 用於識別乘客行程的面向公眾的文本，例如，識別通勤鐵路旅行的火車號碼。如果乘客通常不依賴行程名稱，`trip_short_name`應該是空的。一個`trip_short_name`值（如果提供）應唯一標識服務日內的行程；它不應用於目的地名稱或有限/明確指定。 |
+| `direction_id`          | 枚舉                                                        | 可選的       | 指示旅行的行進方向。該字段不應在路由中使用；它提供了一種在發佈時間表時按方向分隔行程的方法。有效的選項是：<br/><br/>`0` - 單向旅行（例如出境旅行）。 <br/>`1` - 向相反方向行駛（例如入境旅行）。 <hr/>*示例：`trip_headsign`和`direction_id`字段可以一起使用，為一組行程分配一個名稱，以在每個方向上行駛。一個[trips.txt](#tripstxt)文件可以包含這些記錄以在時間表中使用：* <br/> `trip_id,...,trip_headsign,direction_id` <br/> `1234,...,Airport,0` <br/> `1505,...,Downtown,1` |
+| `block_id`              |  ID                                                       | 可選的       | 標識行程所屬的塊。一個區塊由使用同一車輛的單次行程或多次連續行程組成，由共享服務天數和`block_id`.一個`block_id`可能有不同服務天數的行程，形成不同的區塊。見[下面的例子](#example-blocks-and-service-day).提供座位轉移信息，[轉移](#transferstxt)的`transfer_type` `4`應改為提供。 |
+| `shape_id`              | 國外身份證參考`shapes.shape_id`                                  | **有條件要求** | 標識描述旅行的車輛行駛路徑的地理空間形狀。 <br/><br/>有條件要求：<br/> -**必需的**如果行程具有連續接送或下車行為定義`routes.txt`或在`stop_times.txt` .<br/> - 否則可選。 |
+| `wheelchair_accessible` | 枚舉                                                        | 可選的       | 表示輪椅可及性。有效的選項是：<br/><br/>`0`或為空 - 沒有行程的無障礙信息。 <br/>`1` - 在此特定行程中使用的車輛可容納至少一名坐在輪椅上的乘客。 <br/>`2` - 此行程不接待坐輪椅的乘客。 |
+| `bikes_allowed`         | 枚舉                                                        | 可選的       | 指示是否允許騎自行車。有效的選項是：<br/><br/>`0`或為空 - 沒有行程的自行車信息。 <br/>`1` - 在這次特定旅行中使用的車輛可以容納至少一輛自行車。 <br/>`2` - 此行程不允許騎自行車。 |
 
 
-#### 示例：街区和服务日
+#### 示例：街區和服務日
 
-下面的示例是有效的，一周中的每一天都有不同的块。
+下面的示例是有效的，一周中的每一天都有不同的塊。
 
 
 | route_id | trip_id | service_id                     | block_id | <span style="font-weight:normal">*(first stop time)*</span> | <span style="font-weight:normal">*(last stop time)*</span> |
@@ -251,314 +251,314 @@ search:
 | red      | trip_4  | mon-tues-wed-thurs             | red_loop | 20:00:00                                | 20:50:00                |
 | red      | trip_5  | mon-tues-wed-thurs             | red_loop | 21:00:00                                | 21:50:00                |
 
-上表注意事项：
+上表注意事項：
 
-* 例如，从周五到周六早上，单车运行`trip_1` 、 `trip_2`和`trip_3` （晚上 10:00 到凌晨 12:55）。请注意，最后一次行程发生在星期六的 12:00 AM 到 12:55 AM，但属于星期五“服务日”的一部分，因为时间是 24:00:00 到 24:55:00。
-* 周一、周二、周三和周四，晚上 8:00 到晚上 10:55，单车在一个街区内运行`trip_1` 、 `trip_4`和`trip_5` 。
+* 例如，從周五到週六早上，單車運行`trip_1` 、 `trip_2`和`trip_3` （晚上 10:00 到凌晨 12:55）。請注意，最後一次行程發生在星期六的 12:00 AM 到 12:55 AM，但屬於星期五“服務日”的一部分，因為時間是 24:00:00 到 24:55:00。
+* 週一、週二、週三和周四，晚上 8:00 到晚上 10:55，單車在一個街區內運行`trip_1` 、 `trip_4`和`trip_5` 。
 
 
 ### stop_times.txt
 
 文件：**必填**
 
-首要的关键 （trip_id ,stop_sequence )
+首要的關鍵 （trip_id ,stop_sequence )
 
-| 字段名称                  | 类型                     | 在场        | 描述                                                                                                                                                                                                                                                                                                                                                                                                                  |   |
+| 字段名稱                  | 類型                     | 在場        | 描述                                                                                                                                                                                                                                                                                                                                                                                                                  |   |
 | --------------------- | ---------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | - |
-| `trip_id`             | 国外身份证参考`trips.trip_id` | **必需的**   | 标识行程。                                                                                                                                                                                                                                                                                                                                                                                                               |   |
-| `arrival_time`        | 时间                     | **有条件要求** | 到达站点的时间（定义为`stop_times.stop_id`) 用于特定行程（定义为`stop_times.trip_id`）。<br/><br/>如果停靠点没有不同的到达和离开时间，`arrival_time`和`departure_time`应该是一样的。<br/><br/>对于在服务日午夜之后发生的时间，请以大于 24:00:00 的值输入时间，以旅行当天的 HH:MM:SS 本地时间Schedule开始。<br/><br/>如果准确的到达和离开时间（`timepoint=1`或空）不可用，估计或插值到达和离开时间（`timepoint=0` ) 应提供。<br/><br/>有条件要求：<br/> -**必需的**旅行中的第一站和最后一站（定义为`stop_times.stop_sequence`）。<br/> -**必需的**为了`timepoint=1` .<br/> - 否则可选。 |   |
-| `departure_time`      | 时间                     | **有条件要求** | 从站点出发的时间（定义为`stop_times.stop_id`) 用于特定行程（定义为`stop_times.trip_id` ）。 <br/><br/>如果停靠点没有不同的到达和离开时间，`arrival_time`和`departure_time`应该是一样的。<br/><br/>对于在服务日午夜之后发生的时间，请以大于 24:00:00 的值输入时间，以旅行当天的 HH:MM:SS 本地时间Schedule开始。<br/><br/>如果准确的到达和离开时间（`timepoint=1`或空）不可用，估计或插值到达和离开时间（`timepoint=0` ) 应提供。<br/><br/>有条件要求：<br/> -**必需的**为了`timepoint=1` .<br/> - 否则可选。                                                        |   |
-| `stop_id`             | 国外身份证参考`stops.stop_id` | **必需的**   | 标识服务停止。旅行期间服务的所有站点必须在[stop_times.txt](#stop_timestxt).参考位置必须是站点/平台，即它们的`stops.location_type`值必须是`0`或为空。在同一个行程中，一个站点可以服务多次，并且多个行程和路线可以为同一个站点提供服务。                                                                                                                                                                                                                                                                    |   |
-| `stop_sequence`       | 非负整数                   | **必需的**   | 特定行程的停靠顺序。这些值必须随着行程增加，但不需要是连续的。<hr/>*示例：行程中的第一个位置可能有`stop_sequence` =`1`，旅途中的第二个地点可能有`stop_sequence` =`23`，第三个位置可能有`stop_sequence` =`40`， 等等。*                                                                                                                                                                                                                                                                      |   |
-| `stop_headsign`       | 文本                     | 可选的       | 出现在标牌上的文字，用于向乘客指明行程的目的地。此字段覆盖默认值`trips.trip_headsign`当headsign在停止之间变化时。如果在整个行程中都显示头标，`trips.trip_headsign`应改为使用。<br/><br/>一个`stop_headsign`为一指定的值`stop_time`不适用于后续`stop_time`s 在同一次旅行中。如果你想覆盖`trip_headsign`对于多个`stop_time`s 在同一次旅行中，`stop_headsign`值必须在每个重复`stop_time`排。                                                                                                                                           |   |
-| `pickup_type`         | 枚举                     | 可选的       | 表示取货方式。有效的选项是：<br/><br/>`0`或空 - 定期取货。<br/>`1` - 不提供接送服务。<br/>`2` - 必须打电话给代理商安排取件。<br/>`3` - 必须与司机协调安排接送。                                                                                                                                                                                                                                                                                                            |   |
-| `drop_off_type`       | 枚举                     | 可选的       | 表示下车方式。有效的选项是：<br/><br/>`0`或空车 - 定期下车。<br/>`1` - 不提供下车服务。<br/>`2` - 必须致电代理安排下车。<br/>`3` - 必须与司机协调安排下车。                                                                                                                                                                                                                                                                                                              |   |
-| `continuous_pickup`   | 枚举                     | 可选的       | 表示骑手可以在车辆行驶路径上的任何点登上运输车辆，如`shapes.txt` ， 由此`stop_time`到下一个`stop_time`在旅途中`stop_sequence`.有效的选项是：<br/><br/>`0` - 连续停止皮卡。<br/>`1`或空 - 没有连续停止拾取。<br/>`2` - 必须打电话给代理安排连续停止取件。<br/>`3` - 必须与司机协调安排连续停车接送。<br/><br/>如果填充此字段，它会覆盖定义的任何连续拾取行为`routes.txt`.如果此字段为空，则`stop_time`继承定义的任何连续拾取行为`routes.txt` .                                                                                                                   |   |
-| `continuous_drop_off` | 枚举                     | 可选的       | 表示骑手可以在车辆行驶路径上的任何点从运输车辆下车，如下所述`shapes.txt`， 由此`stop_time`到下一个`stop_time`在旅途中`stop_sequence` .有效的选项是：<br/><br/>`0`- 连续停止下降。<br/>`1`或空 - 没有连续停止下降。<br/>`2` - 必须打电话给代理商安排连续的中途下车。<br/>`3` - 必须与司机协调安排连续停车下车。<br/><br/>如果填充此字段，它将覆盖定义的任何连续下降行为`routes.txt`.如果此字段为空，则`stop_time`继承定义在`routes.txt` .                                                                                                                      |   |
-| `shape_dist_traveled` | 非负浮动                   | 可选的       | 沿相关形状行进的实际距离，从第一个停靠点到此记录中指定的停靠点。此字段指定在行程中任意两个停靠点之间要绘制多少形状。必须使用相同的单位[shapes.txt](#shapestxt).用于的值`shape_dist_traveled`必须随着`stop_sequence`;它们不得用于显示沿路线的反向行驶。<hr/>*示例：如果一辆公共汽车从形状的起点到终点的距离为 5.25 公里，`shape_dist_traveled` =`5.25` .*                                                                                                                                                                                   |   |
-| `timepoint`           | 枚举                     | 可选的       | 指示车辆是否严格遵守停靠点的到达和离开时间，或者它们是否是近似和/或插值时间。该字段允许GTFS生产者提供插值的停止时间，同时指示时间是近似的。有效的选项是：<br/><br/>`0` - 时间被认为是近似的。<br/>`1`或空 - 时间被认为是准确的。                                                                                                                                                                                                                                                                                    |   |
+| `trip_id`             | 國外身份證參考`trips.trip_id` | **必需的**   | 標識行程。 |   |
+| `arrival_time`        | 時間                     | **有條件要求** | 到達站點的時間（定義為`stop_times.stop_id`) 用於特定行程（定義為`stop_times.trip_id`）。 <br/><br/>如果停靠點沒有不同的到達和離開時間，`arrival_time`和`departure_time`應該是一樣的。 <br/><br/>對於在服務日午夜之後發生的時間，請以大於 24:00:00 的值輸入時間，以旅行當天的 HH:MM:SS 本地時間Schedule開始。 <br/><br/>如果準確的到達和離開時間（`timepoint=1`或空）不可用，估計或插值到達和離開時間（`timepoint=0` ) 應提供。 <br/><br/>有條件要求：<br/> -**必需的**旅行中的第一站和最後一站（定義為`stop_times.stop_sequence`）。 <br/> -**必需的**為了`timepoint=1` .<br/> - 否則可選。 |   |
+| `departure_time`      | 時間                     | **有條件要求** | 從站點出發的時間（定義為`stop_times.stop_id`) 用於特定行程（定義為`stop_times.trip_id` ）。 <br/><br/>如果停靠點沒有不同的到達和離開時間，`arrival_time`和`departure_time`應該是一樣的。 <br/><br/>對於在服務日午夜之後發生的時間，請以大於 24:00:00 的值輸入時間，以旅行當天的 HH:MM:SS 本地時間Schedule開始。 <br/><br/>如果準確的到達和離開時間（`timepoint=1`或空）不可用，估計或插值到達和離開時間（`timepoint=0` ) 應提供。 <br/><br/>有條件要求：<br/> -**必需的**為了`timepoint=1` .<br/> - 否則可選。 |   |
+| `stop_id`             | 國外身份證參考`stops.stop_id` | **必需的**   | 標識服務停止。旅行期間服務的所有站點必須在[stop_times.txt](#stop_timestxt).參考位置必須是站點/平台，即它們的`stops.location_type`值必須是`0`或為空。在同一個行程中，一個站點可以服務多次，並且多個行程和路線可以為同一個站點提供服務。 |   |
+| `stop_sequence`       | 非負整數                   | **必需的**   | 特定行程的停靠順序。這些值必須隨著行程增加，但不需要是連續的。 <hr/>*示例：行程中的第一個位置可能有`stop_sequence` =`1`，旅途中的第二個地點可能有`stop_sequence` =`23`，第三個位置可能有`stop_sequence` =`40`， 等等。 *                                                                                                                                                                                                                                                                      |   |
+| `stop_headsign`       | 文本                     | 可選的       | 出現在標牌上的文字，用於向乘客指明行程的目的地。此字段覆蓋默認值`trips.trip_headsign`當headsign在停止之間變化時。如果在整個行程中都顯示頭標，`trips.trip_headsign`應改為使用。 <br/><br/>一個`stop_headsign`為一指定的值`stop_time`不適用於後續`stop_time`s 在同一次旅行中。如果你想覆蓋`trip_headsign`對於多個`stop_time`s 在同一次旅行中，`stop_headsign`值必須在每個重複`stop_time`排。 |   |
+| `pickup_type`         | 枚舉                     | 可選的       | 表示取貨方式。有效的選項是：<br/><br/>`0`或空 - 定期取貨。 <br/>`1` - 不提供接送服務。 <br/>`2` - 必須打電話給代理商安排取件。 <br/>`3` - 必須與司機協調安排接送。 |   |
+| `drop_off_type`       | 枚舉                     | 可選的       | 表示下車方式。有效的選項是：<br/><br/>`0`或空車 - 定期下車。 <br/>`1` - 不提供下車服務。 <br/>`2` - 必須致電代理安排下車。 <br/>`3` - 必須與司機協調安排下車。 |   |
+| `continuous_pickup`   | 枚舉                     | 可選的       | 表示騎手可以在車輛行駛路徑上的任何點登上運輸車輛，如`shapes.txt` ， 由此`stop_time`到下一個`stop_time`在旅途中`stop_sequence`.有效的選項是：<br/><br/>`0` - 連續停止皮卡。 <br/>`1`或空 - 沒有連續停止拾取。 <br/>`2` - 必須打電話給代理安排連續停止取件。 <br/>`3` - 必須與司機協調安排連續停車接送。 <br/><br/>如果填充此字段，它會覆蓋定義的任何連續拾取行為`routes.txt`.如果此字段為空，則`stop_time`繼承定義的任何連續拾取行為`routes.txt` .                                                                                                                   |   |
+| `continuous_drop_off` | 枚舉                     | 可選的       | 表示騎手可以在車輛行駛路徑上的任何點從運輸車輛下車，如下所述`shapes.txt`， 由此`stop_time`到下一個`stop_time`在旅途中`stop_sequence` .有效的選項是：<br/><br/>`0`- 連續停止下降。 <br/>`1`或空 - 沒有連續停止下降。 <br/>`2` - 必須打電話給代理商安排連續的中途下車。 <br/>`3` - 必須與司機協調安排連續停車下車。 <br/><br/>如果填充此字段，它將覆蓋定義的任何連續下降行為`routes.txt`.如果此字段為空，則`stop_time`繼承定義在`routes.txt` .|   |
+| `shape_dist_traveled` | 非負浮動                   | 可選的       | 沿相關形狀行進的實際距離，從第一個停靠點到此記錄中指定的停靠點。此字段指定在行程中任意兩個停靠點之間要繪製多少形狀。必須使用相同的單位[shapes.txt](#shapestxt).用於的值`shape_dist_traveled`必須隨著`stop_sequence`;它們不得用於顯示沿路線的反向行駛。 <hr/>*示例：如果一輛公共汽車從形狀的起點到終點的距離為 5.25 公里，`shape_dist_traveled` =`5.25` .*                                                                                                                                                                                   |   |
+| `timepoint`           | 枚舉                     | 可選的       | 指示車輛是否嚴格遵守停靠點的到達和離開時間，或者它們是否是近似和/或插值時間。該字段允許GTFS生產者提供插值的停止時間，同時指示時間是近似的。有效的選項是：<br/><br/>`0` - 時間被認為是近似的。 <br/>`1`或空 - 時間被認為是準確的。 |   |
 
 ### calendar.txt
 
-文件：**有条件要求**
+文件：**有條件要求**
 
-首要的关键 （service_id )
+首要的關鍵 （service_id )
 
-| 字段名称         | 类型   | 在场      | 描述                                                                                                                                                                           |
+| 字段名稱         | 類型   | 在場      | 描述                                                                                                                                                                           |
 | ------------ | ---- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `service_id` | 唯一身份 | **必需的** | 确定服务可用于一条或多条路线的一组日期。每个`service_id`值必须是唯一的[calendar.txt](#calendartxt)文件。                                                                                                     |
-| `monday`     | 枚举   | **必需的** | 指示服务是否在指定日期范围内的所有星期一运行`start_date`和`end_date`字段。请注意，特定日期的例外情况可能会在[calendar_dates.txt](#calendar_datestxt) .有效的选项是：<br/><br/>`1`- 服务适用于日期范围内的所有星期一。<br/>`0` - 日期范围内的星期一不提供服务。 |
-| `tuesday`    | 枚举   | **必需的** | 功能同上`monday`周二除外                                                                                                                                                             |
-| `wednesday`  | 枚举   | **必需的** | 功能同上`monday`周三除外                                                                                                                                                             |
-| `thursday`   | 枚举   | **必需的** | 功能同上`monday`周四除外                                                                                                                                                             |
-| `friday`     | 枚举   | **必需的** | 功能同上`monday`周五除外                                                                                                                                                             |
-| `saturday`   | 枚举   | **必需的** | 功能同上`monday`周六除外。                                                                                                                                                            |
-| `sunday`     | 枚举   | **必需的** | 功能同上`monday`周日除外。                                                                                                                                                            |
-| `start_date` | 日期   | **必需的** | 保养间隔的开始保养日。                                                                                                                                                                  |
-| `end_date`   | 日期   | **必需的** | 服务间隔的结束服务日。该服务日包括在间隔中。                                                                                                                                                       |
+| `service_id` | 唯一身份 | **必需的** | 確定服務可用於一條或多條路線的一組日期。每個`service_id`值必須是唯一的[calendar.txt](#calendartxt)文件。 |
+| `monday`     | 枚舉   | **必需的** | 指示服務是否在指定日期範圍內的所有星期一運行`start_date`和`end_date`字段。請注意，特定日期的例外情況可能會在[calendar_dates.txt](#calendar_datestxt) .有效的選項是：<br/><br/>`1`- 服務適用於日期範圍內的所有星期一。 <br/>`0` - 日期範圍內的星期一不提供服務。 |
+| `tuesday`    | 枚舉   | **必需的** | 功能同上`monday`週二除外                                                                                                                                                             |
+| `wednesday`  | 枚舉   | **必需的** | 功能同上`monday`週三除外                                                                                                                                                             |
+| `thursday`   | 枚舉   | **必需的** | 功能同上`monday`週四除外                                                                                                                                                             |
+| `friday`     | 枚舉   | **必需的** | 功能同上`monday`週五除外                                                                                                                                                             |
+| `saturday`   | 枚舉   | **必需的** | 功能同上`monday`週六除外。 |
+| `sunday`     | 枚舉   | **必需的** | 功能同上`monday`週日除外。 |
+| `start_date` | 日期   | **必需的** | 保養間隔的開始保養日。 |
+| `end_date`   | 日期   | **必需的** | 服務間隔的結束服務日。該服務日包括在間隔中。 |
 
 ### calendar_dates.txt
 
-文件：**有条件要求**
+文件：**有條件要求**
 
-首要的关键 （service_id , `date` )
+首要的關鍵 （service_id , `date` )
 
-这calendar_dates.txt表按日期显式激活或禁用服务。它可以以两种方式使用。
+這calendar_dates.txt表按日期顯式激活或禁用服務。它可以以兩種方式使用。
 
-* 推荐：使用calendar_dates.txt和这个结合calendar.txt定义中定义的默认服务模式的例外calendar.txt .如果服务通常是定期的，在明确的日期有一些变化（例如，为了适应特殊活动服务，或学校Schedule)，这是一个很好的方法。在这种情况下`calendar_dates. service_id`service_id是一个外国 ID 参考`calendar. service_id`service_id .
-* 替代：省略calendar.txt ，并指定每个服务日期calendar_dates.txt .这允许相当大的服务变化并适应没有正常每周时间表的服务。在这种情况下service_id是一个身份证。
+* 推薦：使用calendar_dates.txt和這個結合calendar.txt定義中定義的默認服務模式的例外calendar.txt .如果服務通常是定期的，在明確的日期有一些變化（例如，為了適應特殊活動服務，或學校Schedule)，這是一個很好的方法。在這種情況下`calendar_dates. service_id`service_id是一個外國 ID 參考`calendar. service_id`service_id .
+* 替代：省略calendar.txt ，並指定每個服務日期calendar_dates.txt .這允許相當大的服務變化並適應沒有正常每週時間表的服務。在這種情況下service_id是一個身份證。
 
-| 字段名称             | 类型                               | 在场      | 描述                                                                                                                                                                                                                                                                                                                                                           |
+| 字段名稱             | 類型                               | 在場      | 描述                                                                                                                                                                                                                                                                                                                                                           |
 | ---------------- | -------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `service_id`     | 国外身份证参考`calendar.service_id`或身份证 | **必需的** | 标识一个或多个路由发生服务异常时的一组日期。每个 （`service_id` ,`date` ) 对只能出现一次[calendar_dates.txt](#calendar_datestxt)如果使用[calendar.txt](#calendartxt)和[calendar_dates.txt](#calendar_datestxt)同时。如果一个`service_id`值出现在两者中[calendar.txt](#calendartxt)和[calendar_dates.txt](#calendar_datestxt), 中的信息[calendar_dates.txt](#calendardatestxt)修改指定的服务信息[calendar.txt](#calendartxt) . |
-| `date`           | 日期                               | **必需的** | 发生服务异常的日期。                                                                                                                                                                                                                                                                                                                                                   |
-| `exception_type` | 枚举                               | **必需的** | 指示服务是否在日期字段中指定的日期可用。有效的选项是：<br/><br/> `1` - 已在指定日期添加服务。<br/>`2` - 已在指定日期删除服务。<hr/>*示例：假设一条路线在节假日有一组可用的行程，而在所有其他日子有另一组可用的行程。一`service_id`可以对应于常规服务Schedule和另一个`service_id`可以对应假期Schedule.对于特定的节日，[calendar_dates.txt](#calendar_datestxt)文件可用于将假期添加到假期`service_id`并从常规中删除假期`service_id`Schedule.*                                                             |
+| `service_id`     | 國外身份證參考`calendar.service_id`或身份證 | **必需的** | 標識一個或多個路由發生服務異常時的一組日期。每個 （`service_id` ,`date` ) 對只能出現一次[calendar_dates.txt](#calendar_datestxt)如果使用[calendar.txt](#calendartxt)和[calendar_dates.txt](#calendar_datestxt)同時。如果一個`service_id`值出現在兩者中[calendar.txt](#calendartxt)和[calendar_dates.txt](#calendar_datestxt), 中的信息[calendar_dates.txt](#calendardatestxt)修改指定的服務信息[calendar.txt](#calendartxt) . |
+| `date`           | 日期                               | **必需的** | 發生服務異常的日期。 |
+| `exception_type` | 枚舉                               | **必需的** | 指示服務是否在日期字段中指定的日期可用。有效的選項是：<br/><br/> `1` - 已在指定日期添加服務。 <br/>`2` - 已在指定日期刪除服務。 <hr/>*示例：假設一條路線在節假日有一組可用的行程，而在所有其他日子有另一組可用的行程。一`service_id`可以對應於常規服務Schedule和另一個`service_id`可以對應假期Schedule.對於特定的節日，[calendar_dates.txt](#calendar_datestxt)文件可用於將假期添加到假期`service_id`並從常規中刪除假期`service_id`Schedule.*                                                             |
 
 ### fare_attributes.txt
 
-文件：**可选**
+文件：**可選**
 
-首要的关键 （fare_id )
+首要的關鍵 （fare_id )
 
-**版本**<br/>有两种用于描述票价的建模选项。GTFS -Fares V1 是用于描述最低票价信息的传统选项。GTFS -Fares V2 是一种更新的方法，可以更详细地说明代理商的票价结构。两者都允许出现在数据集中，但数据消费者对于给定的数据集只能使用一种方法。建议GTFS -Fares V2 优先于GTFS -票价 V1。<br/><br/>相关的文件GTFS -票价 V1 是：<br/>-fare_attributes.txt<br/>-fare_rules.txt<br/><br/>相关的文件GTFS -票价 V2 是：<br/>-fare_products.txt<br/>-fare_leg_rules.txt<br/>-fare_transfer_rules.txt
+**版本**<br/>有兩種用於描述票價的建模選項。 GTFS -Fares V1 是用於描述最低票價信息的傳統選項。 GTFS -Fares V2 是一種更新的方法，可以更詳細地說明代理商的票價結構。兩者都允許出現在數據集中，但數據消費者對於給定的數據集只能使用一種方法。建議GTFS -Fares V2 優先於GTFS -票價 V1。 <br/><br/>相關的文件GTFS -票價 V1 是：<br/>-fare_attributes.txt<br/>-fare_rules.txt<br/><br/>相關的文件GTFS -票價 V2 是：<br/>-fare_products.txt<br/>-fare_leg_rules.txt<br/>-fare_transfer_rules.txt
 
 <br/>
 
-| 字段名称                | 类型                        | 在场        | 描述                                                                                                     |
+| 字段名稱                | 類型                        | 在場        | 描述                                                                                                     |
 | ------------------- | ------------------------- | --------- | ------------------------------------------------------------------------------------------------------ |
-| `fare_id`           | 唯一身份                      | **必需的**   | 标识票价等级。                                                                                                |
-| `price`             | 非负浮动                      | **必需的**   | 票价，单位为`currency_type` .                                                                                |
-| `currency_type`     | 货币代码                      | **必需的**   | 用于支付票价的货币。                                                                                             |
-| `payment_method`    | 枚举                        | **必需的**   | 指示必须支付票价的时间。有效的选项是：<br/><br/>`0` - 车费在船上支付。<br/>`1` - 必须在登机前支付车费。                                      |
-| `transfers`         | 枚举                        | **必需的**   | 表示此票价允许的换乘次数。有效的选项是：<br/><br/>`0` - 此票价不允许换乘。<br/>`1` - 车手可以转移一次。<br/>`2` - 车手可以转移两次。<br/>空 - 允许无限制转移。 |
-| `agency_id`         | 国外身份证参考`agency.agency_id` | **有条件要求** | 标识票价的相关机构。<br/><br/>有条件要求：<br/> -**必需的**如果定义了多个机构`agency.txt` .<br/> - 否则可选。                           |
-| `transfer_duration` | 非负整数                      | 可选的       | 传输到期前的时间长度（以秒为单位）。什么时候`transfers` =`0`此字段可用于指示票的有效期或留空。                                                |
+| `fare_id`           | 唯一身份                      | **必需的**   | 標識票價等級。 |
+| `price`             | 非負浮動                      | **必需的**   | 票價，單位為`currency_type` .                                                                                |
+| `currency_type`     | 貨幣代碼                      | **必需的**   | 用於支付票價的貨幣。 |
+| `payment_method`    | 枚舉                        | **必需的**   | 指示必須支付票價的時間。有效的選項是：<br/><br/>`0` - 車費在船上支付。 <br/>`1` - 必須在登機前支付車費。 |
+| `transfers`         | 枚舉                        | **必需的**   | 表示此票價允許的換乘次數。有效的選項是：<br/><br/>`0` - 此票價不允許換乘。 <br/>`1` - 車手可以轉移一次。 <br/>`2` - 車手可以轉移兩次。 <br/>空 - 允許無限制轉移。 |
+| `agency_id`         | 國外身份證參考`agency.agency_id` | **有條件要求** | 標識票價的相關機構。 <br/><br/>有條件要求：<br/> -**必需的**如果定義了多個機構`agency.txt` .<br/> - 否則可選。 |
+| `transfer_duration` | 非負整數                      | 可選的       | 傳輸到期前的時間長度（以秒為單位）。什麼時候`transfers` =`0`此字段可用於指示票的有效期或留空。 |
 
 ### fare_rules.txt
 
-文件：**有条件要求**
+文件：**有條件要求**
 
-主键 ( `*` )
+主鍵 ( `*` )
 
-这fare_rules.txt表指定票价如何fare_attributes.txt申请行程。大多数票价结构使用以下规则的某种组合：
+這fare_rules.txt表指定票價如何fare_attributes.txt申請行程。大多數票價結構使用以下規則的某種組合：
 
-* 票价取决于始发站或目的地站。
-* 票价取决于行程经过的区域。
-* 票价取决于行程使用的路线。
+* 票價取決於始發站或目的地站。
+* 票價取決於行程經過的區域。
+* 票價取決於行程使用的路線。
 
-有关演示如何指定票价结构的示例fare_rules.txt和fare_attributes.txt ，请参阅 GoogleTransitDataFeed 开源项目 wiki 中的<https://code.google.com/p/googletransitdatafeed/wiki/FareExamples> 。
+有關演示如何指定票價結構的示例fare_rules.txt和fare_attributes.txt ，請參閱 GoogleTransitDataFeed 開源項目 wiki 中的<https://code.google.com/p/googletransitdatafeed/wiki/FareExamples> 。
 
-| 字段名称             | 类型                               | 在场      | 描述                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| 字段名稱             | 類型                               | 在場      | 描述                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | ---------------- | -------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `fare_id`        | 国外身份证参考`fare_attributes.fare_id` | **必需的** | 标识票价等级。                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| `route_id`       | 国外身份证参考`routes.route_id`         | 可选的     | 标识与票价等级关联的路线。如果存在多条具有相同票价属性的路线，请在[fare_rules.txt](#fare_rules.txt)对于每条路线。<hr/>*示例：如果票价等级“b”在路线“TSW”和“TSE”上有效，则[fare_rules.txt](#fare_rules.txt)文件将包含票价等级的这些记录：* <br/> `  fare_id,route_id `<br/>`b,TSW` <br/> `b,TSE`                                                                                                                                                                                                                                                                                |
-| `origin_id`      | 国外身份证参考`stops.zone_id`           | 可选的     | 标识一个原始区域。如果一个票价舱位有多个始发区，请在[fare_rules.txt](#fare_rules.txt)对于每个`origin_id` .<hr/>*示例：如果票价等级“b”适用于从“2”区或“8”区出发的所有旅行，则[fare_rules.txt](#fare_rules.txt)文件将包含票价等级的这些记录：* <br/> `fare_id,...,origin_id` <br/> `b,...,2`  <br/> `b,...,8`                                                                                                                                                                                                                                                                 |
-| `destination_id` | 国外身份证参考`stops.zone_id`           | 可选的     | 标识目标区域。如果票价等级有多个目的地区域，请在[fare_rules.txt](#fare_rules.txt)对于每个`destination_id` .<hr/>*示例：`origin_id`和`destination_id`可以一起使用字段来指定票价等级“b”对于区域 3 和 4 之间的旅行有效，对于区域 3 和 5 之间的旅行，[fare_rules.txt](#fare_rules.txt)文件将包含票价等级的这些记录：* <br/>`fare_id,...,origin_id,destination_id` <br/>`b,...,3,4`<br/> `b,...,3,5`                                                                                                                                                                                            |
-| `contains_id`    | 国外身份证参考`stops.zone_id`           | 可选的     | 识别乘客在使用给定票价等级时将进入的区域。在某些系统中用于计算正确的票价等级。<hr/>*示例：如果票价等级“c”与经过 5、6 和 7 区的 GRT 路线上的所有旅行相关联，则[fare_rules.txt](#fare_rules.txt)将包含这些记录：* <br/> `fare_id,route_id,...,contains_id` <br/>  `c,GRT,...,5` <br/>`c,GRT,...,6` <br/>`c,GRT,...,7` <br/> *因为所有`contains_id`必须匹配区域才能应用票价，经过 5 区和 6 区但不经过 7 区的行程将没有票价等级“c”。有关更多详细信息，请参阅[ https://code.google.com/p/googletransitdatafeed/wiki/FareExamples](https://code.google.com/p/googletransitdatafeed/wiki/FareExamples)在 GoogleTransitDataFeed 项目 wiki 中。* |
+| `fare_id`        | 國外身份證參考`fare_attributes.fare_id` | **必需的** | 標識票價等級。|
+| `route_id`       | 國外身份證參考`routes.route_id`         | 可選的     | 標識與票價等級關聯的路線。如果存在多條具有相同票價屬性的路線，請在[fare_rules.txt](#fare_rules.txt)對於每條路線。 <hr/>*示例：如果票價等級“b”在路線“TSW”和“TSE”上有效，則[fare_rules.txt](#fare_rules.txt)文件將包含票價等級的這些記錄：* <br/> `  fare_id,route_id `<br/>`b,TSW` <br/> `b,TSE`                                                                                                                                                                                                                                                                                |
+| `origin_id`      | 國外身份證參考`stops.zone_id`           | 可選的     | 標識一個原始區域。如果一個票價艙位有多個始發區，請在[fare_rules.txt](#fare_rules.txt)對於每個`origin_id` .<hr/>*示例：如果票價等級“b”適用於從“2”區或“8”區出發的所有旅行，則[fare_rules.txt](#fare_rules.txt)文件將包含票價等級的這些記錄：* <br/> `fare_id,...,origin_id` <br/> `b,...,2`  <br/> `b,...,8`                                                                                                                                                                                                                                                                 |
+| `destination_id` | 國外身份證參考`stops.zone_id`           | 可選的     | 標識目標區域。如果票價等級有多個目的地區域，請在[fare_rules.txt](#fare_rules.txt)對於每個`destination_id` .<hr/>*示例：`origin_id`和`destination_id`可以一起使用字段來指定票價等級“b”對於區域 3 和 4 之間的旅行有效，對於區域 3 和 5 之間的旅行，[fare_rules.txt](#fare_rules.txt)文件將包含票價等級的這些記錄：* <br/>`fare_id,...,origin_id,destination_id` <br/>`b,...,3,4`<br/> `b,...,3,5`                                                                                                                                                                                            |
+| `contains_id`    | 國外身份證參考`stops.zone_id`           | 可選的     | 識別乘客在使用給定票價等級時將進入的區域。在某些系統中用於計算正確的票價等級。 <hr/>*示例：如果票價等級“c”與經過 5、6 和 7 區的 GRT 路線上的所有旅行相關聯，則[fare_rules.txt](#fare_rules.txt)將包含這些記錄：* <br/> `fare_id,route_id,...,contains_id` <br/>  `c,GRT,...,5` <br/>`c,GRT,...,6` <br/>`c,GRT,...,7` <br/> *因為所有`contains_id`必須匹配區域才能應用票價，經過 5 區和 6 區但不經過 7 區的行程將沒有票價等級“c”。有關更多詳細信息，請參閱[ https://code.google.com/p/googletransitdatafeed/wiki/FareExamples](https://code.google.com/p/googletransitdatafeed/wiki/FareExamples)在 GoogleTransitDataFeed 項目 wiki 中。 * |
 
 
 ### fare_products.txt
 
-文件：**可选**
+文件：**可選**
 
-首要的关键 （fare_product_id )
+首要的關鍵 （fare_product_id )
 
-描述乘客可以购买的不同类型的车票或票价。
+描述乘客可以購買的不同類型的車票或票價。
 
-| 字段名称                | 类型   | 在场      | 描述                                 |
+| 字段名稱                | 類型   | 在場      | 描述                                 |
 | ------------------- | ---- | ------- | ---------------------------------- |
-| `fare_product_id`   |  ID  | **必需的** | 标识票价产品。                            |
-| `fare_product_name` | 文本   | 可选的     | 向乘客显示的票价产品的名称。                     |
-| `amount`            | 货币金额 | **必需的** | 票价产品的成本。可能为负数表示转让折扣。可能为零表示免费的票价产品。 |
-| `currency`          | 货币代码 | **必需的** | 票价产品成本的货币。                         |
+| `fare_product_id`   |  ID  | **必需的** | 標識票價產品。 |
+| `fare_product_name` | 文本   | 可選的     | 向乘客顯示的票價產品的名稱。 |
+| `amount`            | 貨幣金額 | **必需的** | 票價產品的成本。可能為負數表示轉讓折扣。可能為零表示免費的票價產品。 |
+| `currency`          | 貨幣代碼 | **必需的** | 票價產品成本的貨幣。 |
 
 
 ### fare_leg_rules.txt
 
-文件：**可选**
+文件：**可選**
 
-首要的关键 （network_id `network_id , from_area_id , to_area_id , fare_product_id`from_area_id `network_id , from_area_id , to_area_id , fare_product_id`to_area_id `network_id , from_area_id , to_area_id , fare_product_id`fare_product_id )
+首要的關鍵 （network_id `network_id , from_area_id , to_area_id , fare_product_id`from_area_id `network_id , from_area_id , to_area_id , fare_product_id`to_area_id `network_id , from_area_id , to_area_id , fare_product_id`fare_product_id )
 
-单程旅行的票价规则。
+單程旅行的票價規則。
 
-票价fare_leg_rules.txt必须通过过滤文件中的所有记录来查找与骑手要行驶的腿相匹配的规则来查询。
+票價fare_leg_rules.txt必須通過過濾文件中的所有記錄來查找與騎手要行駛的腿相匹配的規則來查詢。
 
-要处理一条腿的成本：
+要處理一條腿的成本：
 
-1. 文件fare_leg_rules.txt必须按定义旅行特征的字段进行过滤，这些字段是：
+1. 文件fare_leg_rules.txt必須按定義旅行特徵的字段進行過濾，這些字段是：
    - `fare_leg_rules. network_id`network_id
    - `fare_leg_rules. from_area_id`from_area_id
    - `fare_leg_rules. to_area_id`to_area_id<br/>
 
 <br/>
 
-2. 如果腿与记录完全匹配fare_leg_rules.txt根据旅行的特点，必须处理该记录以确定行程的费用。
-3. 如果未找到完全匹配项，则`fare_leg_rules. network_id`network_id , `fare_leg_rules. from_area_id`from_area_id , 和`fare_leg_rules. to_area_id`to_area_id必须检查以处理腿的成本：
-   - `fare_leg_rules. network_id`network_id对应于定义的所有网络routes.txt不包括`fare_leg_rules. network_id`network_id
-   - `fare_leg_rules. from_area_id`from_area_id对应于area中定义的所有`areas. area_id`area_id不包括`fare_leg_rules. from_area_id`from_area_id
-   - `fare_leg_rules. to_area_id`to_area_id对应于area中定义的所有`areas. area_id`area_id不包括`fare_leg_rules. to_area_id`to_area_id<br/>
+2. 如果腿與記錄完全匹配fare_leg_rules.txt根據旅行的特點，必須處理該記錄以確定行程的費用。
+3. 如果未找到完全匹配項，則`fare_leg_rules. network_id`network_id , `fare_leg_rules. from_area_id`from_area_id , 和`fare_leg_rules. to_area_id`to_area_id必須檢查以處理腿的成本：
+   - `fare_leg_rules. network_id`network_id對應於定義的所有網絡routes.txt不包括`fare_leg_rules. network_id`network_id
+   - `fare_leg_rules. from_area_id`from_area_id對應於area中定義的所有`areas. area_id`area_id不包括`fare_leg_rules. from_area_id`from_area_id
+   - `fare_leg_rules. to_area_id`to_area_id對應於area中定義的所有`areas. area_id`area_id不包括`fare_leg_rules. to_area_id`to_area_id<br/>
 
 <br/>
 
-4. 如果航段不符合上述任何规则，则票价未知。
+4. 如果航段不符合上述任何規則，則票價未知。
 
 <br/>
 
-| 字段名称              | 类型                                     | 在场      | 描述                                                                                                                                                                                                                                                                                                                                                                                  |
+| 字段名稱              | 類型                                     | 在場      | 描述                                                                                                                                                                                                                                                                                                                                                                                  |
 | ----------------- | -------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `leg_group_id`    |  ID                                    | 可选的     | 标识一组条目[fare_leg_rules.txt](#fare_leg_rulestxt) .<br/><br/>用于描述之间的票价转移规则`fare_transfer_rules.from_leg_group_id`和`fare_transfer_rules.to_leg_group_id` .<br/><br/>中的多个条目[fare_leg_rules.txt](#fare_leg_rulestxt)可能属于同一个`fare_leg_rules.leg_group_id` .<br/><br/>相同的条目[fare_leg_rules.txt](#fare_leg_rulestxt)（不包括`fare_leg_rules.leg_group_id`) 不能属于多个`fare_leg_rules.leg_group_id` . |
-| `network_id`      | 国外身份证参考`routes.network_id`             | 可选的     | 标识适用票价段规则的路线网络。<br/><br/>如果没有匹配`fare_leg_rules.network_id`的价值观`network_id`被过滤，为空`fare_leg_rules.network_id`默认会匹配。<br/><br/>中的一个空条目`fare_leg_rules.network_id`对应于定义的所有网络`routes.txt`不包括下面列出的那些`fare_leg_rules.network_id`                                                                                                                                                            |
-| `from_area_id`    | 国外身份证参考`areas.area_id`                 | 可选的     | 标识出发区。<br/><br/>如果没有匹配`fare_leg_rules.from_area_id`的价值观`area_id`被过滤，为空`fare_leg_rules.from_area_id`默认会匹配。<br/><br/>中的一个空条目`fare_leg_rules.from_area_id`对应于定义的所有区域`areas.area_id`不包括下面列出的那些`fare_leg_rules.from_area_id`                                                                                                                                                             |
-| `to_area_id`      | 国外身份证参考`areas.area_id`                 | 可选的     | 标识到达区域。<br/><br/>如果没有匹配`fare_leg_rules.to_area_id`的价值观`area_id`被过滤，为空`fare_leg_rules.to_area_id`默认会匹配。<br/><br/>中的一个空条目`fare_leg_rules.to_area_id`对应于定义的所有区域`areas.area_id`不包括下面列出的那些`fare_leg_rules.to_area_id`                                                                                                                                                                    |
-| `fare_product_id` | 国外身份证参考`fare_products.fare_product_id` | **必需的** | 行程所需的票价产品。                                                                                                                                                                                                                                                                                                                                                                          |
+| `leg_group_id`    |  ID                                    | 可選的     | 標識一組條目[fare_leg_rules.txt](#fare_leg_rulestxt) .<br/><br/>用於描述之間的票價轉移規則`fare_transfer_rules.from_leg_group_id`和`fare_transfer_rules.to_leg_group_id` .<br/><br/>中的多個條目[fare_leg_rules.txt](#fare_leg_rulestxt)可能屬於同一個`fare_leg_rules.leg_group_id` .<br/><br/>相同的條目[fare_leg_rules.txt](#fare_leg_rulestxt)（不包括`fare_leg_rules.leg_group_id`) 不能屬於多個`fare_leg_rules.leg_group_id` . |
+| `network_id`      | 國外身份證參考`routes.network_id`             | 可選的     | 標識適用票價段規則的路線網絡。 <br/><br/>如果沒有匹配`fare_leg_rules.network_id`的價值觀`network_id`被過濾，為空`fare_leg_rules.network_id`默認會匹配。 <br/><br/>中的一個空條目`fare_leg_rules.network_id`對應於定義的所有網絡`routes.txt`不包括下面列出的那些`fare_leg_rules.network_id`                                                                                                                                                            |
+| `from_area_id`    | 國外身份證參考`areas.area_id`                 | 可選的     | 標識出發區。 <br/><br/>如果沒有匹配`fare_leg_rules.from_area_id`的價值觀`area_id`被過濾，為空`fare_leg_rules.from_area_id`默認會匹配。 <br/><br/>中的一個空條目`fare_leg_rules.from_area_id`對應於定義的所有區域`areas.area_id`不包括下面列出的那些`fare_leg_rules.from_area_id`                                                                                                                                                             |
+| `to_area_id`      | 國外身份證參考`areas.area_id`                 | 可選的     | 標識到達區域。 <br/><br/>如果沒有匹配`fare_leg_rules.to_area_id`的價值觀`area_id`被過濾，為空`fare_leg_rules.to_area_id`默認會匹配。 <br/><br/>中的一個空條目`fare_leg_rules.to_area_id`對應於定義的所有區域`areas.area_id`不包括下面列出的那些`fare_leg_rules.to_area_id`                                                                                                                                                                    |
+| `fare_product_id` | 國外身份證參考`fare_products.fare_product_id` | **必需的** | 行程所需的票價產品。 |
 
 
 ### fare_transfer_rules.txt
 
-文件：**可选**
+文件：**可選**
 
-首要的关键 （from_leg_group_id `from_leg_group_id , to_leg_group_id , fare_product_id , transfer_count , duration_limit`to_leg_group_id `from_leg_group_id , to_leg_group_id , fare_product_id , transfer_count , duration_limit`fare_product_id `from_leg_group_id , to_leg_group_id , fare_product_id , transfer_count , duration_limit`transfer_count `from_leg_group_id , to_leg_group_id , fare_product_id , transfer_count , duration_limit`duration_limit )
+首要的關鍵 （from_leg_group_id `from_leg_group_id , to_leg_group_id , fare_product_id , transfer_count , duration_limit`to_leg_group_id `from_leg_group_id , to_leg_group_id , fare_product_id , transfer_count , duration_limit`fare_product_id `from_leg_group_id , to_leg_group_id , fare_product_id , transfer_count , duration_limit`transfer_count `from_leg_group_id , to_leg_group_id , fare_product_id , transfer_count , duration_limit`duration_limit )
 
-中定义的旅行航段之间换乘的票价规则fare_leg_rules.txt .
+中定義的旅行航段之間換乘的票價規則fare_leg_rules.txt .
 
-处理多段旅程的成本：
+處理多段旅程的成本：
 
-1. 中定义的适用票价段组fare_leg_rules.txt应根据骑手的行程为所有单独的行程段确定。
+1. 中定義的適用票價段組fare_leg_rules.txt應根據騎手的行程為所有單獨的行程段確定。
 
-2. 文件fare_transfer_rules.txt必须通过定义传输特征的字段进行过滤，这些字段是：
+2. 文件fare_transfer_rules.txt必須通過定義傳輸特徵的字段進行過濾，這些字段是：
    - `fare_transfer_rules. from_leg_group_id`from_leg_group_id
    - `fare_transfer_rules. to_leg_group_id`to_leg_group_id<br/>
    <br/>
 
-3. 如果转移与记录完全匹配fare_transfer_rules.txt根据转移的特征，必须处理该记录以确定转移成本。
+3. 如果轉移與記錄完全匹配fare_transfer_rules.txt根據轉移的特徵，必須處理該記錄以確定轉移成本。
 
-4. 如果没有找到完全匹配，则在from_leg_group_id或在to_leg_group_id必须检查以处理转移成本：
-   - `fare_transfer_rules. from_leg_group_id`from_leg_group_id对应于`fare_leg_rules.leg_group_id`下定义的所有航段组，不包括 fare_transfer_rules 下列出的航段组`fare_transfer_rules. from_leg_group_id`from_leg_group_id
-   - `fare_transfer_rules. to_leg_group_id`to_leg_group_id对应于`fare_leg_rules.leg_group_id`下定义的所有航段组，不包括 fare_transfer_rules 下列出的航段组`fare_transfer_rules. to_leg_group_id`to_leg_group_id<br/>
+4. 如果沒有找到完全匹配，則在from_leg_group_id或在to_leg_group_id必須檢查以處理轉移成本：
+   - `fare_transfer_rules. from_leg_group_id`from_leg_group_id對應於`fare_leg_rules.leg_group_id`下定義的所有航段組，不包括 fare_transfer_rules 下列出的航段組`fare_transfer_rules. from_leg_group_id`from_leg_group_id
+   - `fare_transfer_rules. to_leg_group_id`to_leg_group_id對應於`fare_leg_rules.leg_group_id`下定義的所有航段組，不包括 fare_transfer_rules 下列出的航段組`fare_transfer_rules. to_leg_group_id`to_leg_group_id<br/>
    <br/>
 
-5. 如果转移不符合上述任何规则，则没有转移安排，并且腿被认为是分开的。
+5. 如果轉移不符合上述任何規則，則沒有轉移安排，並且腿被認為是分開的。
 
 <br/>
 
 
-| 字段名称                | 类型                                   | 在场  | 描述                                                                                                                                                                                                                                                                                         |
+| 字段名稱                | 類型                                   | 在場  | 描述                                                                                                                                                                                                                                                                                         |
 | ------------------- | ------------------------------------ | --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `from_leg_group_id` | 国外身份证参考`fare_leg_rules.leg_group_id` | 可选的 | 标识一组转乘前票价段规则。<br/><br/>如果没有匹配`fare_transfer_rules.from_leg_group_id`的价值观`leg_group_id`被过滤，为空`fare_transfer_rules.from_leg_group_id`默认会匹配。<br/><br/>中的一个空条目`fare_transfer_rules.from_leg_group_id`对应于下定义的所有腿组`fare_leg_rules.leg_group_id`不包括下面列出的那些`fare_transfer_rules.from_leg_group_id` |
-| `to_leg_group_id`   | 国外身份证参考`fare_leg_rules.leg_group_id` | 可选的 | 标识一组转换后票价段规则。<br/><br/>如果没有匹配`fare_transfer_rules.to_leg_group_id`的价值观`leg_group_id`被过滤，为空`fare_transfer_rules.to_leg_group_id`默认会匹配。<br/><br/>中的一个空条目`fare_transfer_rules.to_leg_group_id`对应于下定义的所有腿组`fare_leg_rules.leg_group_id`不包括下面列出的那些`fare_transfer_rules.to_leg_group_id`         |
-| `transfer_count` |非零整数 |**有条件禁止**|定义传输规则可以应用于多少连续传输。<br/><br/>有效的选项是：<br/>`-1` - 没有限制。<br/>`1`或更多 - 定义传输规则可能跨越的传输数量。<br/><br/>如果一个子旅程匹配多个不同的记录transfer_count s，那么最小的规则transfer_count大于或等于子旅程当前传输计数的将被选择。<br/><br/>有条件禁止：<br/>-**禁止**如果`fare_transfer_rules. from_leg_group_id`from_leg_group_id不等于`fare_transfer_rules. to_leg_group_id`to_leg_group_id .<br/>- 如果`fare_transfer_rules. from_leg_group_id`是**必需**的。from_leg_group_id等于`fare_transfer_rules. to_leg_group_id`to_leg_group_id . |
-|duration_limit |正整数 |可选 |定义传输的持续时间限制。<br/><br/>必须以秒为增量的整数表示。<br/><br/>如果没有持续时间限制， `fare_transfer_rules. duration_limit`duration_limit必须为空。 || `duration_limit_type` |枚举 |**有条件要求**|定义`fare_transfer_rules. duration_limit`duration_limit .<br/><br/>有效的选项是：<br/>`0` - 当前航段的出发票价验证和下一航段的到达票价验证之间。<br/>`1` - 在当前航段的出发票价验证和下一航段的出发票价验证之间。<br/>`2` - 在当前航段的到达票价验证和下一航段的出发票价验证之间。<br/>`3` - 在当前航段的到达票价验证和下一航段的到达票价验证之间。<br/><br/>有条件要求：<br/>- 如果`fare_transfer_rules. duration_limit`是**必需**的。duration_limit被定义为。<br/>-**禁止**如果`fare_transfer_rules. duration_limit`duration_limit是空的。 |
-| `fare_transfer_type` | 枚举 | **必填** | 表示旅程中段间中转的费用处理方式：<br/>![](../assets/2-leg.svg)<br/>有效的选项是：<br/>`0` - `fare_leg_rules.fare_product_id`加上`fare_transfer_rules.fare_product_id` ；甲+乙。<br/>`1` - `fare_leg_rules.fare_product_id`加上`fare_transfer_rules.fare_product_id`加上到段`fare_leg_rules.fare_product_id` ；甲+乙+乙。<br/>`2` - `fare_transfer_rules.fare_product_id` ； AB。<br/><br/>旅程中多次转移之间的成本处理交互：<br/>![](../assets/3-leg.svg)<br/><table><thead><tr><th>`fare_transfer_type`</th><th>加工 A > B</th><th>加工 B > C</th></tr></thead><tbody><tr><td>`0`</td><td>A + AB</td><td>S + BC</td></tr><tr><td>`1`</td><td>A + AB +B</td><td>S + BC + C</td></tr><tr><td>`2`</td><td>AB</td><td>S + BC</td></tr></tbody></table>其中 S 表示前一個分支和轉移的總處理成本。 |
-| `fare_product_id` |引用`fare_products. fare_product_id`fare_product_id |可选 |在两个票价段之间转移所需的票价产品。如果为空，则传输规则的成本为 0。|<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>
+| `from_leg_group_id` | 國外身份證參考`fare_leg_rules.leg_group_id` | 可選的 | 標識一組轉乘前票價段規則。 <br/><br/>如果沒有匹配`fare_transfer_rules.from_leg_group_id`的價值觀`leg_group_id`被過濾，為空`fare_transfer_rules.from_leg_group_id`默認會匹配。 <br/><br/>中的一個空條目`fare_transfer_rules.from_leg_group_id`對應於下定義的所有腿組`fare_leg_rules.leg_group_id`不包括下面列出的那些`fare_transfer_rules.from_leg_group_id` |
+| `to_leg_group_id`   | 國外身份證參考`fare_leg_rules.leg_group_id` | 可選的 | 標識一組轉換後票價段規則。 <br/><br/>如果沒有匹配`fare_transfer_rules.to_leg_group_id`的價值觀`leg_group_id`被過濾，為空`fare_transfer_rules.to_leg_group_id`默認會匹配。 <br/><br/>中的一個空條目`fare_transfer_rules.to_leg_group_id`對應於下定義的所有腿組`fare_leg_rules.leg_group_id`不包括下面列出的那些`fare_transfer_rules.to_leg_group_id`         |
+| `transfer_count` |非零整數 |**有條件禁止**|定義傳輸規則可以應用於多少連續傳輸。 <br/><br/>有效的選項是：<br/>`-1` - 沒有限制。 <br/>`1`或更多 - 定義傳輸規則可能跨越的傳輸數量。 <br/><br/>如果一個子旅程匹配多個不同的記錄transfer_count s，那麼最小的規則transfer_count大於或等於子旅程當前傳輸計數的將被選擇。 <br/><br/>有條件禁止：<br/>-**禁止**如果`fare_transfer_rules. from_leg_group_id`from_leg_group_id不等於`fare_transfer_rules. to_leg_group_id`to_leg_group_id .<br/>- 如果`fare_transfer_rules. from_leg_group_id`是**必需**的。 from_leg_group_id等於`fare_transfer_rules. to_leg_group_id`to_leg_group_id . |
+|duration_limit |正整數 |可選 |定義傳輸的持續時間限制。 <br/><br/>必須以秒為增量的整數表示。 <br/><br/>如果沒有持續時間限制， `fare_transfer_rules. duration_limit`duration_limit必須為空。 || `duration_limit_type` |枚舉 |**有條件要求**|定義`fare_transfer_rules. duration_limit`duration_limit .<br/><br/>有效的選項是：<br/>`0` - 當前航段的出發票價驗證和下一航段的到達票價驗證之間。 <br/>`1` - 在當前航段的出發票價驗證和下一航段的出發票價驗證之間。 <br/>`2` - 在當前航段的到達票價驗證和下一航段的出發票價驗證之間。 <br/>`3` - 在當前航段的到達票價驗證和下一航段的到達票價驗證之間。 <br/><br/>有條件要求：<br/>- 如果`fare_transfer_rules. duration_limit`是**必需**的。 duration_limit被定義為。 <br/>-**禁止**如果`fare_transfer_rules. duration_limit`duration_limit是空的。 |
+| `fare_transfer_type` | 枚舉 | **必填** | 表示旅程中段間中轉的費用處理方式：<br/>![](../assets/2-leg.svg)<br/>有效的選項是：<br/>`0` - `fare_leg_rules.fare_product_id`加上`fare_transfer_rules.fare_product_id` ；甲+乙。 <br/>`1` - `fare_leg_rules.fare_product_id`加上`fare_transfer_rules.fare_product_id`加上到段`fare_leg_rules.fare_product_id` ；甲+乙+乙。 <br/>`2` - `fare_transfer_rules.fare_product_id` ； AB。 <br/><br/>旅程中多次轉移之間的成本處理交互：<br/>![](../assets/3-leg.svg)<br/><table><thead><tr><th>`fare_transfer_type`</th><th>加工 A > B</th><th>加工 B > C</th></tr></thead><tbody><tr><td>`0`</td><td>A + AB</td><td>S + BC</td></tr><tr><td>`1`</td><td>A + AB +B</td><td>S + BC + C</td></tr><tr><td>`2`</td><td>AB</td><td>S + BC</td></tr></tbody></table>其中 S 表示前一個分支和轉移的總處理成本。 |
+| `fare_product_id` |引用`fare_products. fare_product_id`fare_product_id |可選 |在兩個票價段之間轉移所需的票價產品。如果為空，則傳輸規則的成本為 0。 |<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>
 
 ### areas.txt
 
-文件：**可选**
+文件：**可選**
 
-首要的关键 （area_id )
+首要的關鍵 （area_id )
 
-定义区域标识符。
+定義區域標識符。
 
-| 字段名称        | 类型   | 在场      | 描述                                    |
+| 字段名稱        | 類型   | 在場      | 描述                                    |
 | ----------- | ---- | ------- | ------------------------------------- |
-| `area_id`   | 唯一身份 | **必需的** | 标识一个区域。必须是唯一的[areas.txt](#areastxt) . |
-| `area_name` | 文本   | **可选的** | 向骑手显示的区域名称。                           |
+| `area_id`   | 唯一身份 | **必需的** | 標識一個區域。必須是唯一的[areas.txt](#areastxt) . |
+| `area_name` | 文本   | **可選的** | 向騎手顯示的區域名稱。 |
 
 ### stop_areas.txt
 
-文件：**可选**
+文件：**可選**
 
-主键 ( `*` )
+主鍵 ( `*` )
 
-指定站点从stops.txt到地区。
+指定站點從stops.txt到地區。
 
-| 字段名称      | 类型                     | 在场      | 描述                                                                                                                                                    |
+| 字段名稱      | 類型                     | 在場      | 描述                                                                                                                                                    |
 | --------- | ---------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `area_id` | 国外身份证参考`areas.area_id` | **必需的** | 识别一个或多个区域`stop_id`属于。相同`stop_id`可以定义在很多`area_id` s。                                                                                                   |
-| `stop_id` | 国外身份证参考`stops.stop_id` | **必需的** | 标识一个停靠点。如果一个站（即停止与`stops.location_type=1`) 在该字段中定义，假设它的所有平台（即全部以`stops.location_type=0`有这个站定义为`stops.parent_station`) 是同一区域的一部分。可以通过将平台分配给其他区域来覆盖此行为。 |
+| `area_id` | 國外身份證參考`areas.area_id` | **必需的** | 識別一個或多個區域`stop_id`屬於。相同`stop_id`可以定義在很多`area_id` s。 |
+| `stop_id` | 國外身份證參考`stops.stop_id` | **必需的** | 標識一個停靠點。如果一個站（即停止與`stops.location_type=1`) 在該字段中定義，假設它的所有平台（即全部以`stops.location_type=0`有這個站定義為`stops.parent_station`) 是同一區域的一部分。可以通過將平台分配給其他區域來覆蓋此行為。 |
 
 ### shapes.txt
 
-文件：**可选**
+文件：**可選**
 
-首要的关键 （shape_id ,shape_pt_sequence )
+首要的關鍵 （shape_id ,shape_pt_sequence )
 
-形状描述车辆沿路线路线行驶的路径，并在文件中定义shapes.txt .形状与行程相关联，由车辆按顺序通过的一系列点组成。形状不需要精确地截取停靠点的位置，但行程中的所有停靠点都应位于该行程的形状的一小段距离内，即靠近连接形状点的直线段。
+形狀描述車輛沿路線路線行駛的路徑，並在文件中定義shapes.txt .形狀與行程相關聯，由車輛按順序通過的一系列點組成。形狀不需要精確地截取停靠點的位置，但行程中的所有停靠點都應位於該行程的形狀的一小段距離內，即靠近連接形狀點的直線段。
 
-| 字段名称                  | 类型   | 在场      | 描述                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| 字段名稱                  | 類型   | 在場      | 描述                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | --------------------- | ---- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `shape_id`            |  ID  | **必需的** | 标识一个形状。                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| `shape_pt_lat`        | 纬度   | **必需的** | 形状点的纬度。中的每条记录[shapes.txt](#shapestxt)表示用于定义形状的形状点。                                                                                                                                                                                                                                                                                                                                                                                     |
-| `shape_pt_lon`        | 经度   | **必需的** | 形状点的经度。                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| `shape_pt_sequence`   | 非负整数 | **必需的** | 形状点连接以形成形状的顺序。值必须随行程增加，但不需要是连续的。<hr/>*示例：如果形状“A_shp”在其定义中包含三个点，则[shapes.txt](#shapestxt)文件可能包含这些记录来定义形状：* <br/> `shape_id,shape_pt_lat,shape_pt_lon,shape_pt_sequence` <br/> `A_shp,37.61956,-122.48161,0` <br/> `A_shp,37.64430,-122.41070,6` <br/> `A_shp,37.65863,-122.30839,11`                                                                                                                                                    |
-| `shape_dist_traveled` | 非负浮动 | 可选的     | 从第一个形状点到此记录中指定的点沿形状行进的实际距离。旅行计划者用来在地图上显示正确的形状部分。值必须随着增加`shape_pt_sequence`;它们不得用于显示沿路线的反向行驶。距离单位必须与所使用的一致[stop_times.txt](#stop_timestxt) .<hr/>*示例：如果一辆公共汽车沿着上面为 A_shp 定义的三个点行驶，附加的`shape_dist_traveled`值（此处以公里显示）如下所示：* <br/> `shape_id,shape_pt_lat,shape_pt_lon,shape_pt_sequence,shape_dist_traveled` <br/> `A_shp,37.61956,-122.48161,0,0`<br/>`A_shp,37.64430,-122.41070,6,6.8310` <br/> `A_shp,37.65863,-122.30839,11,15.8765` |
+| `shape_id`            |  ID  | **必需的** | 標識一個形狀。 |
+| `shape_pt_lat`        | 緯度   | **必需的** | 形狀點的緯度。中的每條記錄[shapes.txt](#shapestxt)表示用於定義形狀的形狀點。|
+| `shape_pt_lon`        | 經度   | **必需的** | 形狀點的經度。 |
+| `shape_pt_sequence`   | 非負整數 | **必需的** | 形狀點連接以形成形狀的順序。值必須隨行程增加，但不需要是連續的。 <hr/>*示例：如果形狀“A_shp”在其定義中包含三個點，則[shapes.txt](#shapestxt)文件可能包含這些記錄來定義形狀：* <br/> `shape_id,shape_pt_lat,shape_pt_lon,shape_pt_sequence` <br/> `A_shp,37.61956,-122.48161,0` <br/> `A_shp,37.64430,-122.41070,6` <br/> `A_shp,37.65863,-122.30839,11`                                                                                                                                                    |
+| `shape_dist_traveled` | 非負浮動 | 可選的     | 從第一個形狀點到此記錄中指定的點沿形狀行進的實際距離。旅行計劃者用來在地圖上顯示正確的形狀部分。值必須隨著增加`shape_pt_sequence`;它們不得用於顯示沿路線的反向行駛。距離單位必須與所使用的一致[stop_times.txt](#stop_timestxt) .<hr/>*示例：如果一輛公共汽車沿著上面為 A_shp 定義的三個點行駛，附加的`shape_dist_traveled`值（此處以公里顯示）如下所示：* <br/> `shape_id,shape_pt_lat,shape_pt_lon,shape_pt_sequence,shape_dist_traveled` <br/> `A_shp,37.61956,-122.48161,0,0`<br/>`A_shp,37.64430,-122.41070,6,6.8310` <br/> `A_shp,37.65863,-122.30839,11,15.8765` |
 
 ### frequencies.txt
 
-文件：**可选**
+文件：**可選**
 
-首要的关键 （trip_id ,start_time )
+首要的關鍵 （trip_id ,start_time )
 
-frequencies.txt表示按常规车距运行的行程（行程之间的时间）。该文件可用于表示两种不同类型的服务。
+frequencies.txt表示按常規車距運行的行程（行程之間的時間）。該文件可用於表示兩種不同類型的服務。
 
-* 基于频率的服务 ( `exact_times` = `0` )，其中服务不遵循固定的Schedule全天。相反，运营商试图严格保持预定的行程间隔。
-* 的压缩表示Schedule-based 服务 ( `exact_times` = `1` )，在指定时间段内具有完全相同的行程。在Schedule化服务经营者尽量严格遵守Schedule.
+* 基於頻率的服務 ( `exact_times` = `0` )，其中服務不遵循固定的Schedule全天。相反，運營商試圖嚴格保持預定的行程間隔。
+* 的壓縮表示Schedule-based 服務 ( `exact_times` = `1` )，在指定時間段內具有完全相同的行程。在Schedule化服務經營者盡量嚴格遵守Schedule.
 
-| 字段名称           | 类型                     | 在场      | 描述                                                                                                                                                                           |
+| 字段名稱           | 類型                     | 在場      | 描述                                                                                                                                                                           |
 | -------------- | ---------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `trip_id`      | 国外身份证参考`trips.trip_id` | **必需的** | 标识指定服务时距适用的行程。                                                                                                                                                               |
-| `start_time`   | 时间                     | **必需的** | 第一辆车以指定车距从行程的第一站出发的时间。                                                                                                                                                       |
-| `end_time`     | 时间                     | **必需的** | 在行程的第一站，服务更改为不同的发车时间（或停止）的时间。                                                                                                                                                |
-| `headway_secs` | 正整数                    | **必需的** | 在指定的时间间隔内，从同一站点（车距）出发的时间（以秒为单位）`start_time`和`end_time` .可以为同一行程定义多个车头时距，但不得重叠。新的进展可能会在前一个进展结束的确切时间开始。                                                                        |
-| `exact_times`  | 枚举                     | 可选的     | 指示旅行的服务类型。有关详细信息，请参阅文件说明。有效的选项是：<br/><br/>`0`或空 - 基于频率的行程。<br/>`1` -Schedule全天以完全相同的进度为基础的旅行。在这种情况下`end_time`值必须大于上次所需的行程`start_time`但少于最后一次想要的行程start_time+`headway_secs` . |
+| `trip_id`      | 國外身份證參考`trips.trip_id` | **必需的** | 標識指定服務時距適用的行程。 |
+| `start_time`   | 時間                     | **必需的** | 第一輛車以指定車距從行程的第一站出發的時間。 |
+| `end_time`     | 時間                     | **必需的** | 在行程的第一站，服務更改為不同的發車時間（或停止）的時間。 |
+| `headway_secs` | 正整數                    | **必需的** | 在指定的時間間隔內，從同一站點（車距）出發的時間（以秒為單位）`start_time`和`end_time` .可以為同一行程定義多個車頭時距，但不得重疊。新的進展可能會在前一個進展結束的確切時間開始。 |
+| `exact_times`  | 枚舉                     | 可選的     | 指示旅行的服務類型。有關詳細信息，請參閱文件說明。有效的選項是：<br/><br/>`0`或空 - 基於頻率的行程。 <br/>`1` -Schedule全天以完全相同的進度為基礎的旅行。在這種情況下`end_time`值必須大於上次所需的行程`start_time`但少於最後一次想要的行程start_time+`headway_secs` . |
 
 ### transfers.txt
 
-文件：**可选**
+文件：**可選**
 
-首要的关键 （from_stop_id ,to_stop_id ,from_trip_id ,to_trip_id ,from_route_id ,to_route_id )
+首要的關鍵 （from_stop_id ,to_stop_id ,from_trip_id ,to_trip_id ,from_route_id ,to_route_id )
 
-在计算行程时，GTFS - 消耗应用程序根据允许的时间插入传输并停止接近。transfers.txt为选定的传输指定附加规则和覆盖。
+在計算行程時，GTFS - 消耗應用程序根據允許的時間插入傳輸並停止接近。 transfers.txt為選定的傳輸指定附加規則和覆蓋。
 
-字段from_trip_id ,to_trip_id ,from_route_id和to_route_id允许更高阶的传输规则特异性。随着from_stop_id和to_stop_id ，特异性排名如下：
+字段from_trip_id ,to_trip_id ,from_route_id和to_route_id允許更高階的傳輸規則特異性。隨著from_stop_id和to_stop_id ，特異性排名如下：
 
-1. 两个都trip_id定义：from_trip_id和to_trip_id .
-2. 一trip_id和route_id集定义：（from_trip_id和to_route_id ） 或者 （from_route_id和to_trip_id ）。
-3. 一trip_id定义：from_trip_id或者to_trip_id .
-4. 两个都route_id定义：from_route_id和to_route_id .
-5. 一route_id定义：from_route_id或者to_route_id .
-6. 仅有的from_stop_id和to_stop_id已定义：未设置路线或行程相关字段。
+1. 兩個都trip_id定義：from_trip_id和to_trip_id .
+2. 一trip_id和route_id集定義：（from_trip_id和to_route_id ） 或者 （from_route_id和to_trip_id ）。
+3. 一trip_id定義：from_trip_id或者to_trip_id .
+4. 兩個都route_id定義：from_route_id和to_route_id .
+5. 一route_id定義：from_route_id或者to_route_id .
+6. 僅有的from_stop_id和to_stop_id已定義：未設置路線或行程相關字段。
 
-对于给定有序的到达行程和出发行程对，选择在这两个行程之间应用的具有最大特异性的转移。对于任何一对旅行，不应该有两个具有同等最大特异性的转移可以适用。
+對於給定有序的到達行程和出發行程對，選擇在這兩個行程之間應用的具有最大特異性的轉移。對於任何一對旅行，不應該有兩個具有同等最大特異性的轉移可以適用。
 
 
-| 字段名称                | 类型                       | 在场        | 描述                                                                                                                                                                                                                                                                                                                                                                                             |
+| 字段名稱                | 類型                       | 在場        | 描述                                                                                                                                                                                                                                                                                                                                                                                             |
 | ------------------- | ------------------------ | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `from_stop_id`      | 国外身份证参考`stops.stop_id`   | **有条件要求** | 标识路线之间开始连接的站点或车站。如果此字段涉及车站，则换乘规则适用于其所有子车站。禁止引用一个站`transfer_types`4 和 5。                                                                                                                                                                                                                                                                                                                        |
-| `to_stop_id`        | 国外身份证参考`stops.stop_id`   | **有条件要求** | 标识路线之间的连接结束的站点或车站。如果此字段涉及车站，则换乘规则适用于所有子站点。禁止引用一个站`transfer_types` 4 和 5。                                                                                                                                                                                                                                                                                                                       |
-| `from_route_id`     | 国外身份证参考`routes.route_id` | 可选的       | 标识连接开始的路由。<br/><br/>如果`from_route_id`已定义，转移将适用于给定路线上的到达行程`from_stop_id` .<br/><br/>如果两者`from_trip_id`和`from_route_id`被定义，`trip_id`必须属于`route_id`， 和`from_trip_id`将优先。                                                                                                                                                                                                                          |
-| `to_route_id`       | 国外身份证参考`routes.route_id` | 可选的       | 标识连接结束的路径。<br/><br/>如果`to_route_id`已定义，转移将适用于给定路线上的出发行程`to_stop_id` .<br/><br/>如果两者`to_trip_id`和`to_route_id`被定义，`trip_id`必须属于`route_id`， 和`to_trip_id`将优先。                                                                                                                                                                                                                                    |
-| `from_trip_id`      | 国外身份证参考`trips.trip_id`   | **有条件要求** | 标识路线之间的连接开始的行程。<br/><br/>如果`from_trip_id`已定义，转移将适用于给定的到达行程`from_stop_id` .<br/><br/>如果两者`from_trip_id`和`from_route_id`被定义，`trip_id`必须属于`route_id`， 和`from_trip_id`将优先。如果需要`transfer_type`是`4`或者`5` .                                                                                                                                                                                           |
-| `to_trip_id`        | 国外身份证参考`trips.trip_id`   | **有条件要求** | 标识路线之间的连接结束的行程。<br/><br/>如果`to_trip_id`已定义，转移将适用于给定的出发行程`to_stop_id` .<br/><br/>如果两者`to_trip_id`和`to_route_id`被定义，`trip_id`必须属于`route_id`， 和`to_trip_id`将优先。如果需要`transfer_type`是`4`或者`5` .                                                                                                                                                                                                     |
-| `transfer_type`     | 枚举                       | **必需的**   | 指示指定的连接类型 (`from_stop_id` ,`to_stop_id` ） 一对。有效的选项是：<br/><br/> `0`或空 - 路线之间的推荐转乘点。<br/>`1` - 两条路线之间的定时换乘点。预计出发的车辆将等待到达的车辆，并留出足够的时间让骑手在路线之间换乘。<br/>`2` - 转移需要在到达和离开之间的最短时间，以确保连接。转移所需的时间由`min_transfer_time` .<br/>`3`- 在该地点的路线之间无法换乘。<br/>`4`- 乘客可以通过留在同一辆车上从一次旅行转移到另一次旅行（“座位内转移”）。有关此类转移的更多详细信息[以下](#linked-trips).<br/>`5` - 连续行程之间不允许进行座位内换乘。乘客必须下车并重新上车。有关此类转移的更多详细信息[以下](#linked-trips) . |
-| `min_transfer_time` | 非负整数                     | 可选的       | 允许在指定站点的路线之间换乘所需的时间量（以秒为单位）。这`min_transfer_time`应该足以允许典型的骑手在两个站点之间移动，包括缓冲时间以允许Schedule每条路线的差异。                                                                                                                                                                                                                                                                                                 |
+|`from_stop_id`      | 國外身份證參考`stops.stop_id`   | **有條件要求** | 標識路線之間開始連接的站點或車站。如果此字段涉及車站，則換乘規則適用於其所有子車站。禁止引用一個站`transfer_types`4 和 5。 |
+| `to_stop_id`        | 國外身份證參考`stops.stop_id`   | **有條件要求** | 標識路線之間的連接結束的站點或車站。如果此字段涉及車站，則換乘規則適用於所有子站點。禁止引用一個站`transfer_types` 4 和 5。 |
+| `from_route_id`     | 國外身份證參考`routes.route_id` | 可選的       | 標識連接開始的路由。 <br/><br/>如果`from_route_id`已定義，轉移將適用於給定路線上的到達行程`from_stop_id` .<br/><br/>如果兩者`from_trip_id`和`from_route_id`被定義，`trip_id`必須屬於`route_id`， 和`from_trip_id`將優先。 |
+| `to_route_id`       | 國外身份證參考`routes.route_id` | 可選的       | 標識連接結束的路徑。 <br/><br/>如果`to_route_id`已定義，轉移將適用於給定路線上的出發行程`to_stop_id` .<br/><br/>如果兩者`to_trip_id`和`to_route_id`被定義，`trip_id`必須屬於`route_id`， 和`to_trip_id`將優先。 |
+| `from_trip_id`      | 國外身份證參考`trips.trip_id`   | **有條件要求** | 標識路線之間的連接開始的行程。 <br/><br/>如果`from_trip_id`已定義，轉移將適用於給定的到達行程`from_stop_id` .<br/><br/>如果兩者`from_trip_id`和`from_route_id`被定義，`trip_id`必須屬於`route_id`， 和`from_trip_id`將優先。如果需要`transfer_type`是`4`或者`5` .                                                                                                                                                                                           |
+| `to_trip_id`        | 國外身份證參考`trips.trip_id`   | **有條件要求** | 標識路線之間的連接結束的行程。 <br/><br/>如果`to_trip_id`已定義，轉移將適用於給定的出發行程`to_stop_id` .<br/><br/>如果兩者`to_trip_id`和`to_route_id`被定義，`trip_id`必須屬於`route_id`， 和`to_trip_id`將優先。如果需要`transfer_type`是`4`或者`5` .                                                                                                                                                                                                     |
+| `transfer_type`     | 枚舉                       | **必需的**   | 指示指定的連接類型 (`from_stop_id` ,`to_stop_id` ） 一對。有效的選項是：<br/><br/> `0`或空 - 路線之間的推薦轉乘點。 <br/>`1` - 兩條路線之間的定時換乘點。預計出發的車輛將等待到達的車輛，並留出足夠的時間讓騎手在路線之間換乘。 <br/>`2` - 轉移需要在到達和離開之間的最短時間，以確保連接。轉移所需的時間由`min_transfer_time` .<br/>`3`- 在該地點的路線之間無法換乘。 <br/>`4`- 乘客可以通過留在同一輛車上從一次旅行轉移到另一次旅行（“座位內轉移”）。有關此類轉移的更多詳細信息[以下](#linked-trips).<br/>`5` - 連續行程之間不允許進行座位內換乘。乘客必須下車並重新上車。有關此類轉移的更多詳細信息[以下](#linked-trips) . |
+| `min_transfer_time` | 非負整數                     | 可選的       | 允許在指定站點的路線之間換乘所需的時間量（以秒為單位）。這`min_transfer_time`應該足以允許典型的騎手在兩個站點之間移動，包括緩衝時間以允許Schedule每條路線的差異。 |
 
-#### 联程旅行
+#### 聯程旅行
 
-以下适用于`transfer_type=4`和`=5` ，它们用于将旅行链接在一起，无论是否有座位内转移。
+以下適用於`transfer_type=4`和`=5` ，它們用於將旅行鏈接在一起，無論是否有座位內轉移。
 
-连接在一起的行程必须由同一辆车运营。车辆可以与其他车辆连接或分离。
+連接在一起的行程必須由同一輛車運營。車輛可以與其他車輛連接或分離。
 
-如果同时提供了链接的行程转移和 block_id 并且它们产生冲突的结果，则应使用链接的行程转移。
+如果同時提供了鏈接的行程轉移和 block_id 並且它們產生衝突的結果，則應使用鏈接的行程轉移。
 
-最后一站from_trip_id应该在地理位置上靠近to_trip_id ，最后到达时间from_trip_id应该早于但接近于第一个出发时间to_trip_id .最后到达时间from_trip_id可能晚于第一个出发时间to_trip_id万一to_trip_id行程发生在随后的服务日。
+最後一站from_trip_id應該在地理位置上靠近to_trip_id ，最後到達時間from_trip_id應該早於但接近於第一個出發時間to_trip_id .最後到達時間from_trip_id可能晚於第一個出發時間to_trip_id萬一to_trip_id行程發生在隨後的服務日。
 
-在常规情况下，行程可以 1 对 1 链接，但也可以 1 对 n、n 对 1 或 n 对 n 链接以表示更复杂的行程继续。例如，两个火车行程（下图中的行程 A 和行程 B）可以在一个公共车站的车辆耦合操作后合并为一个火车行程（行程 C）：
+在常規情況下，行程可以 1 對 1 鏈接，但也可以 1 對 n、n 對 1 或 n 對 n 鏈接以表示更複雜的行程繼續。例如，兩個火車行程（下圖中的行程 A 和行程 B）可以在一個公共車站的車輛耦合操作後合併為一個火車行程（行程 C）：
 
-- 在一对一的延续中， `trips. service_id`service_id对于每个to_trip_id必须相同。
-- 在 n 对 1 的延续中， `trips. service_id`service_id对于每个from_trip_id必须相同。
-- n 对 n 延续必须尊重这两个约束。
-- 旅行可以作为多个不同延续的一部分链接在一起，前提是`trip. service_id`service_id不得在任何服务日重叠。
+- 在一對一的延續中， `trips. service_id`service_id對於每個to_trip_id必須相同。
+- 在 n 對 1 的延續中， `trips. service_id`service_id對於每個from_trip_id必須相同。
+- n 對 n 延續必須尊重這兩個約束。
+- 旅行可以作為多個不同延續的一部分鏈接在一起，前提是`trip. service_id`service_id不得在任何服務日重疊。
 
 <pre>
 旅行甲
@@ -571,108 +571,108 @@ frequencies.txt表示按常规车距运行的行程（行程之间的时间）�
 
 ### pathways.txt
 
-文件：**可选**
+文件：**可選**
 
-首要的关键 （pathway_id )
+首要的關鍵 （pathway_id )
 
-文件pathways.txt和levels.txt使用图形表示来描述地铁或火车站，节点表示位置，边表示路径。
+文件pathways.txt和levels.txt使用圖形表示來描述地鐵或火車站，節點表示位置，邊表示路徑。
 
-要从车站入口/出口（表示为`location_type=2`的位置的节点）导航到平台（表示为`location_type=0`或空的位置的节点），骑手将穿过人行道、检票口、楼梯，和其他表示为路径的边缘。通用节点（用`location_type=3`表示的节点）可用于连接整个车站的路径。
+要從車站入口/出口（表示為`location_type=2`的位置的節點）導航到平台（表示為`location_type=0`或空的位置的節點），騎手將穿過人行道、檢票口、樓梯，和其他表示為路徑的邊緣。通用節點（用`location_type=3`表示的節點）可用於連接整個車站的路徑。
 
-必须在车站中详尽地定义路径。如果定义了任何路径，则假定代表了整个车站的所有路径。因此，以下准则适用：
+必須在車站中詳盡地定義路徑。如果定義了任何路徑，則假定代表了整個車站的所有路徑。因此，以下準則適用：
 
-- 无悬空位置：如果车站内的任何位置有通道，则该车站内的所有位置都应有通道，但有登机区的站台除外（ `location_type=4` ，请参阅下面的指南）。
-- 具有登机区的平台没有路径：具有登机区（ `location_type=4` ）的平台（ `location_type=0`或空）被视为父对象，而不是点。在这种情况下，平台不得分配路径。应为每个平台的登机区分配所有路径。
-- 无锁定平台：每个平台（ `location_type=0`或空）或登机区（ `location_type=4` ）必须通过一些路径链连接到至少一个入口/出口（ `location_type=2` ）。不允许从给定站台通往站外的路径的车站很少见。
+- 無懸空位置：如果車站內的任何位置有通道，則該車站內的所有位置都應有通道，但有登機區的站台除外（ `location_type=4` ，請參閱下面的指南）。
+- 具有登機區的平台沒有路徑：具有登機區（ `location_type=4` ）的平台（ `location_type=0`或空）被視為父對象，而不是點。在這種情況下，平台不得分配路徑。應為每個平台的登機區分配所有路徑。
+- 無鎖定平台：每個平台（ `location_type=0`或空）或登機區（ `location_type=4` ）必須通過一些路徑鏈連接到至少一個入口/出口（ `location_type=2` ）。不允許從給定站台通往站外的路徑的車站很少見。
 
-| 字段名称                     | 类型                     | 在场      | 描述                                                                                                                                                                                                                                                                                                                          |
+| 字段名稱                     |類型                     | 在場      | 描述                                                                                                                                                                                                                                                                                                                          |
 | ------------------------ | ---------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `pathway_id`             | 唯一身份                   | **必需的** | 标识通路。被系统用作记录的内部标识符。在数据集中必须是唯一的。<br/><br/>不同的路径可能具有相同的值`from_stop_id`和`to_stop_id` .<hr/>_示例：当两个自动扶梯并排在相反的方向时，或者当一个楼梯组和电梯从同一个地方到同一个地方时，不同`pathway_id`可能有相同的`from_stop_id`和`to_stop_id`价值观。_                                                                                                                                  |
-| `from_stop_id`           | 国外身份证参考`stops.stop_id` | **必需的** | 路径开始的位置。<br/><br/>必须包含一个`stop_id`标识一个平台（`location_type=0`或空），入口/出口（`location_type=2` ), 通用节点 (`location_type=3` ) 或登机区 (`location_type=4` ）。 <br/><br/>价值观`stop_id`识别电台（`location_type=1` ) 被禁止。                                                                                                                            |
-| `to_stop_id`             | 国外身份证参考`stops.stop_id` | **必需的** | 路径结束的位置。<br/><br/>必须包含一个`stop_id`标识一个平台（`location_type=0`或空），入口/出口（`location_type=2` ), 通用节点 (`location_type=3` ) 或登机区 (`location_type=4` ）。 <br/><br/>价值观`stop_id`识别电台（`location_type=1` ) 被禁止。                                                                                                                            |
-| `pathway_mode`           | 枚举                     | **必需的** | 指定的路径类型 (`from_stop_id` ,`to_stop_id` ） 一对。有效的选项是：<br/><br/>`1` - 走道。<br/>`2` - 楼梯。<br/>`3` - 移动人行道/旅行者。<br/>`4` - 自动扶梯。<br/>`5` - 电梯。<br/>`6` - 收费门（或支付门）：进入车站区域的通道，需要支付证明才能通过。检票口可以将车站的付费区域与未付费区域分开，或者将同一站内的不同付费区域相互分开。该信息可用于避免使用需要乘客支付不必要费用的捷径来引导乘客通过车站，例如引导乘客步行穿过地铁站台到达公交专用道。<br/>`7` - 出入口：从付费区域进入未付费区域的通道，无需支付证明即可通过。 |
-| `is_bidirectional`       | 枚举                     | **必需的** | 表示路径可以走的方向：<br/><br/>`0` - 单向路径，只能从`from_stop_id`至`to_stop_id` .<br/>`1`- 可以双向使用的双向路径。<br/><br/>出入口（`pathway_mode=7` ) 不能是双向的。                                                                                                                                                                                              |
-| `length`                 | 非负浮动                   | 可选的     | 从起始位置开始的路径水平长度（以米为单位）（定义在`from_stop_id`）到目标位置（定义在`to_stop_id` ）。 <br/><br/>建议将此字段用于人行道（`pathway_mode=1` ), 检票口 (`pathway_mode=6` ) 和出口大门 (`pathway_mode=7` ）。                                                                                                                                                               |
-| `traversal_time`         | 正整数                    | 可选的     | 从起始位置穿过路径所需的平均时间（以秒为单位）（定义在`from_stop_id`）到目标位置（定义在`to_stop_id` ）。 <br/><br/>建议将此字段用于移动人行道（`pathway_mode=3` ), 自动扶梯 (`pathway_mode=4` ) 和电梯 (`pathway_mode=5` ）。                                                                                                                                                            |
-| `stair_count`            | 非空整数                   | 可选的     | 路径的楼梯数量。<br/><br/>一个积极的`stair_count`意味着骑手从`from_stop_id`至`to_stop_id`.和一个负面`stair_count`意味着骑手从`from_stop_id`至`to_stop_id` .<br/><br/>建议将此字段用于楼梯（`pathway_mode=2` ）。 <br/><br/>如果只能提供估计的楼梯数，建议 1 层楼大约有 15 个楼梯。                                                                                                               |
-| `max_slope`              | 漂浮                     | 可选的     | 路径的最大坡度比。有效的选项是：<br/><br/>`0`或空 - 没有斜坡。<br/>`Float` - 路径的坡度比，向上为正，向下为负。<br/><br/>该字段只能用于人行道（`pathway_mode=1` ) 和自动人行道 (`pathway_mode=3` ）。 <hr/>_示例：在美国，0.083（也写为 8.3%）是手推轮椅的最大坡度比，即每增加 1m 增加 0.083m（即 8.3cm）。_                                                                                                             |
-| `min_width`              | 正浮动                    | 可选的     | 以米为单位的路径的最小宽度。<br/><br/>如果最小宽度小于 1 米，建议使用此字段。                                                                                                                                                                                                                                                                               |
-| `signposted_as`          | 文本                     | 可选的     | 来自骑手可见的物理标牌的面向公众的文本。<br/><br/>可用于向乘客提供文本指示，例如“跟随标志前往”。中的文字`singposted_as`应该完全显示在标志上的印刷方式。<br/><br/>当物理标牌是多语言时，可以按照以下示例填充和翻译该字段`stops.stop_name`在字段定义中`feed_info.feed_lang` .                                                                                                                                                |
-| `reversed_signposted_as` | 文本                     | 可选的     | 如同`signposted_as`，但是当从`to_stop_id`到`from_stop_id` .                                                                                                                                                                                                                                                                         |
+| `pathway_id`             | 唯一身份                   | **必需的** | 標識通路。被系統用作記錄的內部標識符。在數據集中必須是唯一的。 <br/><br/>不同的路徑可能具有相同的值`from_stop_id`和`to_stop_id` .<hr/>_示例：當兩個自動扶梯並排在相反的方向時，或者當一個樓梯組和電梯從同一個地方到同一個地方時，不同`pathway_id`可能有相同的`from_stop_id`和`to_stop_id`價值觀。 _                                                                                                                                  |
+| `from_stop_id`           | 國外身份證參考`stops.stop_id` | **必需的** | 路徑開始的位置。 <br/><br/>必須包含一個`stop_id`標識一個平台（`location_type=0`或空），入口/出口（`location_type=2` ), 通用節點 (`location_type=3` ) 或登機區 (`location_type=4` ）。 <br/><br/>價值觀`stop_id`識別電台（`location_type=1` ) 被禁止。 |
+| `to_stop_id`             | 國外身份證參考`stops.stop_id` | **必需的** | 路徑結束的位置。 <br/><br/>必須包含一個`stop_id`標識一個平台（`location_type=0`或空），入口/出口（`location_type=2` ), 通用節點 (`location_type=3` ) 或登機區 (`location_type=4` ）。 <br/><br/>價值觀`stop_id`識別電台（`location_type=1` ) 被禁止。 |
+| `pathway_mode`           | 枚舉                     | **必需的** | 指定的路徑類型 (`from_stop_id` ,`to_stop_id` ） 一對。有效的選項是：<br/><br/>`1` - 走道。 <br/>`2` - 樓梯。 <br/>`3` - 移動人行道/旅行者。 <br/>`4` - 自動扶梯。 <br/>`5` - 電梯。 <br/>`6` - 收費門（或支付門）：進入車站區域的通道，需要支付證明才能通過。檢票口可以將車站的付費區域與未付費區域分開，或者將同一站內的不同付費區域相互分開。該信息可用於避免使用需要乘客支付不必要費用的捷徑來引導乘客通過車站，例如引導乘客步行穿過地鐵站台到達公交專用道。 <br/>`7` - 出入口：從付費區域進入未付費區域的通道，無需支付證明即可通過。 |
+| `is_bidirectional`       | 枚舉                     | **必需的** | 表示路徑可以走的方向：<br/><br/>`0` - 單向路徑，只能從`from_stop_id`至`to_stop_id` .<br/>`1`- 可以雙向使用的雙向路徑。 <br/><br/>出入口（`pathway_mode=7` ) 不能是雙向的。 |
+| `length`                 | 非負浮動                   | 可選的     | 從起始位置開始的路徑水平長度（以米為單位）（定義在`from_stop_id`）到目標位置（定義在`to_stop_id` ）。 <br/><br/>建議將此字段用於人行道（`pathway_mode=1` ), 檢票口 (`pathway_mode=6` ) 和出口大門 (`pathway_mode=7` ）。 |
+| `traversal_time`         | 正整數                    | 可選的     | 從起始位置穿過路徑所需的平均時間（以秒為單位）（定義在`from_stop_id`）到目標位置（定義在`to_stop_id` ）。 <br/><br/>建議將此字段用於移動人行道（`pathway_mode=3` ), 自動扶梯 (`pathway_mode=4` ) 和電梯 (`pathway_mode=5` ）。 |
+| `stair_count`            | 非空整數                   | 可選的     | 路徑的樓梯數量。 <br/><br/>一個積極的`stair_count`意味著騎手從`from_stop_id`至`to_stop_id`.和一個負面`stair_count`意味著騎手從`from_stop_id`至`to_stop_id` .<br/><br/>建議將此字段用於樓梯（`pathway_mode=2` ）。 <br/><br/>如果只能提供估計的樓梯數，建議 1 層樓大約有 15 個樓梯。 |
+| `max_slope`              | 漂浮                     | 可選的     | 路徑的最大坡度比。有效的選項是：<br/><br/>`0`或空 - 沒有斜坡。 <br/>`Float` - 路徑的坡度比，向上為正，向下為負。 <br/><br/>該字段只能用於人行道（`pathway_mode=1` ) 和自動人行道 (`pathway_mode=3` ）。 <hr/>_示例：在美國，0.083（也寫為 8.3%）是手推輪椅的最大坡度比，即每增加 1m 增加 0.083m（即 8.3cm）。 _                                                                                                             |
+| `min_width`              | 正浮動                    | 可選的     | 以米為單位的路徑的最小寬度。 <br/><br/>如果最小寬度小於 1 米，建議使用此字段。 |
+| `signposted_as`          | 文本                     | 可選的     | 來自騎手可見的物理標牌的面向公眾的文本。 <br/><br/>可用於向乘客提供文本指示，例如“跟隨標誌前往”。中的文字`singposted_as`應該完全顯示在標誌上的印刷方式。 <br/><br/>當物理標牌是多語言時，可以按照以下示例填充和翻譯該字段`stops.stop_name`在字段定義中`feed_info.feed_lang` .                                                                                                                                                |
+| `reversed_signposted_as` | 文本                     | 可選的| 如同`signposted_as`，但是當從`to_stop_id`到`from_stop_id` .                                                                                                                                                                                                                                                                         |
 
 ### levels.txt
 
-文件：**有条件要求**
+文件：**有條件要求**
 
-首要的关键 （level_id )
+首要的關鍵 （level_id )
 
-描述站中的级别。配合使用很有用pathways.txt , 并且是使用电梯导航路径所必需的 ( `pathway_mode=5` )。
+描述站中的級別。配合使用很有用pathways.txt , 並且是使用電梯導航路徑所必需的 ( `pathway_mode=5` )。
 
-| 字段名称          | 类型   | 在场      | 描述                                                           |
+| 字段名稱          | 類型   | 在場      | 描述                                                           |
 | ------------- | ---- | ------- | ------------------------------------------------------------ |
-| `level_id`    | 唯一身份 | **必需的** | 标识站中的级别。                                                     |
-| `level_index` | 漂浮   | **必需的** | 指示其相对位置的级别的数字索引。<br/><br/>地面应有索引`0`, 地上水平由正指数表示，地下水平由负指数表示。  |
-| `level_name`  | 文本   | 可选的     | 骑手在建筑物或车站内看到的级别名称。<hr/>_示例：乘电梯到“Mezzanine”或“Platform”或“-1”。_ |
+| `level_id`    | 唯一身份 | **必需的** | 標識站中的級別。 |
+| `level_index` | 漂浮   | **必需的** | 指示其相對位置的級別的數字索引。 <br/><br/>地面應有索引`0`, 地上水平由正指數表示，地下水平由負指數表示。 |
+| `level_name`  | 文本   | 可選的     | 騎手在建築物或車站內看到的級別名稱。 <hr/>_示例：乘電梯到“Mezzanine”或“Platform”或“-1”。 _ |
 
 ### translations.txt
 
-文件：**可选**
+文件：**可選**
 
-首要的关键 （table_name ,field_name ,language ,record_id ,record_sub_id ,field_value )
+首要的關鍵 （table_name ,field_name ,language ,record_id ,record_sub_id ,field_value )
 
-在有多种官方语言的地区，交通机构/运营商通常有language- 特定名称和网页。为了最好地为这些地区的骑手服务，数据集包含这些是很有用的language依赖值。
+在有多種官方語言的地區，交通機構/運營商通常有language- 特定名稱和網頁。為了最好地為這些地區的騎手服務，數據集包含這些是很有用的language依賴值。
 
-| 字段名称            | 类型                 | 在场        | 描述                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| 字段名稱            | 類型                 | 在場        | 描述                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | --------------- | ------------------ | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `table_name`    | 枚举                 | **必需的**   | 定义包含要翻译的字段的表。允许的值为：<br/><br/> -`agency`<br/> -`stops`<br/> -`routes`<br/> -`trips`<br/> -`stop_times`<br/> -`pathways`<br/> -`levels`<br/> -`feed_info`<br/> -`attributions`<br/><br/>添加到的任何文件GTFS会有一个`table_name`与上面列出的文件名等效的值（即，不包括`.txt`文件扩展名）。                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| `field_name`    | 文本                 | **必需的**   | 要翻译的字段的名称。具有类型的字段`Text`可以翻译，字段类型`URL` ,`Email`和`Phone number`也可以“翻译”以提供正确的资源language.不应翻译其他类型的字段。                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| `language`      | language代码         | **必需的**   | language的翻译。<br/><br/>如果language与中相同`feed_info.feed_lang`，该字段的原始值将被假定为在没有特定翻译的语言中使用的默认值（如果`default_lang`没有另外说明）。<hr/>_示例：在瑞士，一个官方双语州的城市被正式称为“Biel/Bienne”，但在法语中简称为“Bienne”，在德语中简称为“Biel”。_                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| `translation`   | 文本或 URL 或电子邮件或电话号码 | **必需的**   | 翻译价值。                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| `record_id`     | 外国身份证              | **有条件要求** | 定义对应于要翻译的字段的记录。价值在`record_id`必须是表主键的第一个或唯一一个字段，如每个表的主键属性中定义的那样，如下所示：<br/><br/> -`agency_id`为了`agency.txt`<br/> -`stop_id`为了`stops.txt` ;<br/> -`route_id`为了`routes.txt` ;<br/> -`trip_id`为了`trips.txt` ;<br/> -`trip_id`为了`stop_times.txt` ;<br/> -`pathway_id`为了`pathways.txt` ;<br/> -`level_id`为了`levels.txt` ;<br/> -`attribution_id`为了`attribution.txt` .<br/><br/>上面未定义的表中的字段不应翻译。然而，生产者有时会添加超出官方规范的额外字段，并且这些非官方字段可能会被翻译。下面是推荐的使用方法`record_id`对于这些表：<br/><br/> -`service_id`为了`calendar.txt` ;<br/> -`service_id`为了`calendar_dates.txt` ;<br/> -`fare_id`为了`fare_attributes.txt` ;<br/> -`fare_id`为了`fare_rules.txt` ;<br/> -`shape_id`为了`shapes.txt` ;<br/> -`trip_id`为了`frequencies.txt` ;<br/> -`from_stop_id`为了`transfers.txt` .<br/><br/>有条件要求：<br/> -**禁止的**如果`table_name`是`feed_info` .<br/> -**禁止的**如果`field_value`被定义为。<br/> -**必需的**如果`field_value`是空的。 |
-| `record_sub_id` | 外国身份证              | **有条件要求** | 当表没有唯一 ID 时，帮助包含要翻译的字段的记录。因此，价值在`record_sub_id`是表的二级ID，如下表所定义：<br/><br/> - 无`agency.txt` ;<br/>- 无`stops.txt` ;<br/>- 无`routes.txt` ;<br/>- 无`trips.txt` ;<br/> -`stop_sequence`为了`stop_times.txt` ;<br/>- 无`pathways.txt` ;<br/>- 无`levels.txt` ;<br/>- 无`attributions.txt` .<br/><br/>上面未定义的表中的字段不应翻译。然而，生产者有时会添加超出官方规范的额外字段，并且这些非官方字段可能会被翻译。下面是推荐的使用方法`record_sub_id`对于这些表：<br/><br/>- 无`calendar.txt` ;<br/> -`date`为了`calendar_dates.txt` ;<br/>- 无`fare_attributes.txt` ;<br/> -`route_id`为了`fare_rules.txt` ;<br/>- 无`shapes.txt` ;<br/> -`start_time`为了`frequencies.txt` ;<br/> -`to_stop_id`为了`transfers.txt` .<br/><br/>有条件要求：<br/> -**禁止的**如果`table_name`是`feed_info` .<br/> -**禁止的**如果`field_value`被定义为。<br/> -**必需的**如果`table_name=stop_times`和`record_id`被定义为。                                                                                            |
-| `field_value`   | 文本或 URL 或电子邮件或电话号码 | **有条件要求** | 而不是定义应该通过使用翻译哪个记录`record_id`和`record_sub_id`，该字段可用于定义应翻译的值。使用时，将在由 标识的字段时应用翻译`table_name`和`field_name`包含与中定义的完全相同的值field_value.<br/><br/>该字段必须有**确切地**中定义的值`field_value`.如果只有一部分值匹配`field_value`, 翻译不会被应用。<br/><br/>如果两个翻译规则匹配相同的记录（一个与`field_value`，另一个与`record_id`)，规则与`record_id`优先。<br/><br/>有条件要求：<br/> -**禁止的**如果`table_name`是`feed_info` .<br/> -**禁止的**如果`record_id`被定义为。<br/> -**必需的**如果`record_id`是空的。                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `table_name`    | 枚舉                 | **必需的**   | 定義包含要翻譯的字段的表。允許的值為：<br/><br/> -`agency`<br/> -`stops`<br/> -`routes`<br/> -`trips`<br/> -`stop_times`<br/> -`pathways`<br/> -`levels`<br/> -`feed_info`<br/> -`attributions`<br/><br/>添加到的任何文件GTFS會有一個`table_name`與上面列出的文件名等效的值（即，不包括`.txt`文件擴展名）。 |
+| `field_name`    | 文本                 | **必需的**   | 要翻譯的字段的名稱。具有類型的字段`Text`可以翻譯，字段類型`URL` ,`Email`和`Phone number`也可以“翻譯”以提供正確的資源language.不應翻譯其他類型的字段。 |
+| `language`      | language代碼         | **必需的**   | language的翻譯。 <br/><br/>如果language與中相同`feed_info.feed_lang`，該字段的原始值將被假定為在沒有特定翻譯的語言中使用的默認值（如果`default_lang`沒有另外說明）。 <hr/>_示例：在瑞士，一個官方雙語州的城市被正式稱為“Biel/Bienne”，但在法語中簡稱為“Bienne”，在德語中簡稱為“Biel”。 _|
+| `translation`   | 文本或 URL 或電子郵件或電話號碼 | **必需的**   | 翻譯價值。 |
+| `record_id`     | 外國身份證              | **有條件要求** | 定義對應於要翻譯的字段的記錄。價值在`record_id`必須是表主鍵的第一個或唯一一個字段，如每個表的主鍵屬性中定義的那樣，如下所示：<br/><br/> -`agency_id`為了`agency.txt`<br/> -`stop_id`為了`stops.txt` ;<br/> -`route_id`為了`routes.txt` ;<br/> -`trip_id`為了`trips.txt` ;<br/> -`trip_id`為了`stop_times.txt` ;<br/> -`pathway_id`為了`pathways.txt` ;<br/> -`level_id`為了`levels.txt` ;<br/> -`attribution_id`為了`attribution.txt` .<br/><br/>上面未定義的表中的字段不應翻譯。然而，生產者有時會添加超出官方規範的額外字段，並且這些非官方字段可能會被翻譯。下面是推薦的使用方法`record_id`對於這些表：<br/><br/> -`service_id`為了`calendar.txt` ;<br/> -`service_id`為了`calendar_dates.txt` ;<br/> -`fare_id`為了`fare_attributes.txt` ;<br/> -`fare_id`為了`fare_rules.txt` ;<br/> -`shape_id`為了`shapes.txt` ;<br/> -`trip_id`為了`frequencies.txt` ;<br/> -`from_stop_id`為了`transfers.txt` .<br/><br/>有條件要求：<br/> -**禁止的**如果`table_name`是`feed_info` .<br/> -**禁止的**如果`field_value`被定義為。 <br/> -**必需的**如果`field_value`是空的。 |
+| `record_sub_id` | 外國身份證              | **有條件要求** | 當表沒有唯一 ID 時，幫助包含要翻譯的字段的記錄。因此，價值在`record_sub_id`是表的二級ID，如下表所定義：<br/><br/> - 無`agency.txt` ;<br/>- 無`stops.txt` ;<br/>- 無`routes.txt` ;<br/>- 無`trips.txt` ;<br/> -`stop_sequence`為了`stop_times.txt` ;<br/>- 無`pathways.txt` ;<br/>- 無`levels.txt` ;<br/>- 無`attributions.txt` .<br/><br/>上面未定義的表中的字段不應翻譯。然而，生產者有時會添加超出官方規範的額外字段，並且這些非官方字段可能會被翻譯。下面是推薦的使用方法`record_sub_id`對於這些表：<br/><br/>- 無`calendar.txt` ;<br/> -`date`為了`calendar_dates.txt` ;<br/>- 無`fare_attributes.txt` ;<br/> -`route_id`為了`fare_rules.txt` ;<br/>- 無`shapes.txt` ;<br/> -`start_time`為了`frequencies.txt` ;<br/> -`to_stop_id`為了`transfers.txt` .<br/><br/>有條件要求：<br/> -**禁止的**如果`table_name`是`feed_info` .<br/> -**禁止的**如果`field_value`被定義為。 <br/> -**必需的**如果`table_name=stop_times`和`record_id`被定義為。 |
+| `field_value`   | 文本或 URL 或電子郵件或電話號碼 | **有條件要求** | 而不是定義應該通過使用翻譯哪個記錄`record_id`和`record_sub_id`，該字段可用於定義應翻譯的值。使用時，將在由 標識的字段時應用翻譯`table_name`和`field_name`包含與中定義的完全相同的值field_value.<br/><br/>該字段必須有**確切地**中定義的值`field_value`.如果只有一部分值匹配`field_value`, 翻譯不會被應用。 <br/><br/>如果兩個翻譯規則匹配相同的記錄（一個與`field_value`，另一個與`record_id`)，規則與`record_id`優先。 <br/><br/>有條件要求：<br/> -**禁止的**如果`table_name`是`feed_info` .<br/> -**禁止的**如果`record_id`被定義為。 <br/> -**必需的**如果`record_id`是空的。 |
 
 ### feed_info.txt
 
-文件：**可选**（如果需要，则为**必需**translations.txt提供）
+文件：**可選**（如果需要，則為**必需**translations.txt提供）
 
-主键（无）
+主鍵（無）
 
-该文件包含有关数据集本身的信息，而不是数据集描述的服务。在某些情况下，数据集的发布者与任何机构都是不同的实体。
+該文件包含有關數據集本身的信息，而不是數據集描述的服務。在某些情況下，數據集的發布者與任何機構都是不同的實體。
 
-如果两种引用方法（record_id ,record_sub_id ） 和field_value用于在 2 个不同的行中翻译相同的值，提供的翻译 (record_id ,record_sub_id ) 优先。
+如果兩種引用方法（record_id ,record_sub_id ） 和field_value用於在 2 個不同的行中翻譯相同的值，提供的翻譯 (record_id ,record_sub_id ) 優先。
 
 
-| 字段名称                  | 类型         | 在场      | 描述                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| 字段名稱                  | 類型         | 在場      | 描述|
 | --------------------- | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `feed_publisher_name` | 文本         | **必需的** | 发布数据集的组织的全名。这可能与其中一个相同`agency.agency_name`价值观。                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| `feed_publisher_url`  | 网址         | **必需的** | 数据集发布组织网站的 URL。这可能与其中一个相同`agency.agency_url`价值观。                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| `feed_lang`           | language代码 | **必需的** | 默认language用于此数据集中的文本。此设置有帮助GTFS消费者选择大小写规则等language- 数据集的特定设置。文件`translations.txt`如果需要将文本翻译成默认语言以外的语言，则可以使用。<br/><br/>默认language对于具有多种语言的原始文本的数据集，可能是多语言的。在这种情况下，`feed_lang`字段应包含language代码`mul`由标准 ISO 639-2 定义，并为每个language数据集中使用的应提供`translations.txt`.如果数据集中所有的原文都在同一个language， 然后`mul`不应该使用。<hr/>_示例：考虑来自瑞士等多语言国家的数据集，其原始数据`stops.stop_name`字段填充了不同语言的站点名称。每个站名都是按照占优写的language在该站点的地理位置，例如`Genève`对于讲法语的城市日内瓦，`Zürich`对于讲德语的城市苏黎世，以及`Biel/Bienne`为双语城市比尔/比安。数据集`feed_lang`应该`mul`翻译将在`translations.txt`， 在德国：`Genf` ,`Zürich`和`Biel` ;法语：`Genève` ,`Zurich`和`Bienne` ;用意大利语：`Ginevra` ,`Zurigo`和`Bienna` ;和英文：`Geneva` ,`Zurich`和`Biel/Bienne` ._ |
-| `default_lang`        | language代码 | 可选的     | 定义language当数据消费者不知道language的骑手。往往会`en`（英语）。                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| `feed_start_date`     | 日期         | 可选的     | 数据集提供完整可靠Schedule服务开始期间的信息`feed_start_date`一天到结束`feed_end_date`天。如果不可用，这两天可能会空着。这`feed_end_date`日期不得早于`feed_start_date`日期，如果两者都给出。建议数据集提供者提供Schedule在此期间之外的数据，以告知可能的未来服务，但数据集消费者应注意其非权威状态。如果`feed_start_date`或者`feed_end_date`超出定义的活动日历日期[calendar.txt](#calendartxt)和[calendar_dates.txt](#calendar_datestxt)，数据集明确断言在`feed_start_date`或者`feed_end_date`范围但不包括在活动日历日期中。                                                                                                                                                                                                                                                                               |
-| `feed_end_date`       | 日期         | 可选的     |  （看上面）                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| `feed_version`        | 文本         | 可选的     | 指示其当前版本的字符串GTFS数据集。GTFS - 消费应用程序可以显示此值，以帮助数据集发布者确定是否已合并最新数据集。                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| `feed_contact_email`  | 电子邮件       | 可选的     | 用于沟通的电子邮件地址GTFS数据集和数据发布实践。`feed_contact_email`是技术联系人GTFS - 消耗应用程序。通过以下方式提供客户服务联系信息[agency.txt](#agencytxt) .                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| `feed_contact_url`    | 网址         | 可选的     | 联系信息的 URL、Web 表单、支持台或其他用于与GTFS数据集和数据发布实践。`feed_contact_url`是技术联系人GTFS - 消耗应用程序。通过以下方式提供客户服务联系信息[agency.txt](#agencytxt) .                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `feed_publisher_name` | 文本         | **必需的** | 發布數據集的組織的全名。這可能與其中一個相同`agency.agency_name`價值觀。 |
+| `feed_publisher_url`  | 網址         | **必需的** | 數據集發布組織網站的 URL。這可能與其中一個相同`agency.agency_url`價值觀。 |
+| `feed_lang`           | language代碼 | **必需的** | 默認language用於此數據集中的文本。此設置有幫助GTFS消費者選擇大小寫規則等language- 數據集的特定設置。文件`translations.txt`如果需要將文本翻譯成默認語言以外的語言，則可以使用。 <br/><br/>默認language對於具有多種語言的原始文本的數據集，可能是多語言的。在這種情況下，`feed_lang`字段應包含language代碼`mul`由標準 ISO 639-2 定義，並為每個language數據集中使用的應提供`translations.txt`.如果數據集中所有的原文都在同一個language， 然後`mul`不應該使用。 <hr/>_示例：考慮來自瑞士等多語言國家的數據集，其原始數據`stops.stop_name`字段填充了不同語言的站點名稱。每個站名都是按照佔優寫的language在該站點的地理位置，例如`Genève`對於講法語的城市日內瓦，`Zürich`對於講德語的城市蘇黎世，以及`Biel/Bienne`為雙語城市比爾/比安。數據集`feed_lang`應該`mul`翻譯將在`translations.txt`， 在德國：`Genf` ,`Zürich`和`Biel` ;法語：`Genève` ,`Zurich`和`Bienne` ;用意大利語：`Ginevra` ,`Zurigo`和`Bienna` ;和英文：`Geneva` ,`Zurich`和`Biel/Bienne` ._ |
+| `default_lang`        | language代碼 | 可選的     | 定義language當數據消費者不知道language的騎手。往往會`en`（英語）。 |
+| `feed_start_date`     | 日期         | 可選的     | 數據集提供完整可靠Schedule服務開始期間的信息`feed_start_date`一天到結束`feed_end_date`天。如果不可用，這兩天可能會空著。這`feed_end_date`日期不得早於`feed_start_date`日期，如果兩者都給出。建議數據集提供者提供Schedule在此期間之外的數據，以告知可能的未來服務，但數據集消費者應注意其非權威狀態。如果`feed_start_date`或者`feed_end_date`超出定義的活動日曆日期[calendar.txt](#calendartxt)和[calendar_dates.txt](#calendar_datestxt)，數據集明確斷言在`feed_start_date`或者`feed_end_date`範圍但不包括在活動日曆日期中。 |
+| `feed_end_date`       | 日期         | 可選的     |  （看上面）                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `feed_version`        | 文本         | 可選的     | 指示其當前版本的字符串GTFS數據集。 GTFS - 消費應用程序可以顯示此值，以幫助數據集發布者確定是否已合併最新數據集。|
+| `feed_contact_email`  | 電子郵件       | 可選的     | 用於溝通的電子郵件地址GTFS數據集和數據發布實踐。 `feed_contact_email`是技術聯繫人GTFS - 消耗應用程序。通過以下方式提供客戶服務聯繫信息[agency.txt](#agencytxt) .                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `feed_contact_url`    | 網址         | 可選的     | 聯繫信息的 URL、Web 表單、支持台或其他用於與GTFS數據集和數據發布實踐。 `feed_contact_url`是技術聯繫人GTFS - 消耗應用程序。通過以下方式提供客戶服務聯繫信息[agency.txt](#agencytxt) .                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 
 ### attributions.txt
 
-文件：**可选**
+文件：**可選**
 
-首要的关键 （attribution_id )
+首要的關鍵 （attribution_id )
 
-该文件定义了应用于数据集的属性。
+該文件定義了應用於數據集的屬性。
 
-| 字段名称                | 类型                        | 在场      | 描述                                                                                                                                          |
+| 字段名稱                | 類型                        | 在場      | 描述                                                                                                                                          |
 | ------------------- | ------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `attribution_id`    | 唯一身份                      | 可选的     | 标识数据集或其子集的属性。这对翻译非常有用。                                                                                                                      |
-| `agency_id`         | 国外身份证参考`agency.agency_id` | 可选的     | 归属地适用的机构。<br/><br/>如果一个`agency_id` ,`route_id` ， 或者`trip_id`属性已定义，其他必须为空。如果未指定任何一个，则归因将应用于整个数据集。                                            |
-| `route_id`          | 国外身份证参考`routes.route_id`  | 可选的     | 功能同上`agency_id`除非属性适用于路线。多个属性可能适用于同一路线。                                                                                                     |
-| `trip_id`           | 国外身份证参考`trips.trip_id`    | 可选的     | 功能同上`agency_id`除非归因适用于旅行。多个归因可能适用于同一次旅行。                                                                                                    |
-| `organization_name` | 文本                        | **必需的** | 数据集所属的组织的名称。                                                                                                                                |
-| `is_producer`       | 枚举                        | 可选的     | 组织的角色是生产者。有效的选项是：<br/><br/>`0`或为空 - 组织没有此角色。<br/>`1` - 组织确实有这个角色。<br/><br/>至少其中一个字段`is_producer` ,`is_operator`， 或者`is_authority`应该设置在`1` . |
-| `is_operator`       | 枚举                        | 可选的     | 功能同上`is_producer`除了组织的角色是操作员。                                                                                                               |
-| `is_authority`      | 枚举                        | 可选的     | 功能同上`is_producer`除了组织的作用是权威。                                                                                                                |
-| `attribution_url`   | 网址                        | 可选的     | 组织的 URL。                                                                                                                                    |
-| `attribution_email` | 电子邮件                      | 可选的     | 组织的电子邮件。                                                                                                                                    |
-| `attribution_phone` | 电话号码                      | 可选的     | 组织的电话号码。                                                                                                                                    |
+| `attribution_id`    | 唯一身份                      | 可選的     | 標識數據集或其子集的屬性。這對翻譯非常有用。 |
+| `agency_id`         | 國外身份證參考`agency.agency_id` | 可選的     | 歸屬地適用的機構。 <br/><br/>如果一個`agency_id` ,`route_id` ， 或者`trip_id`屬性已定義，其他必須為空。如果未指定任何一個，則歸因將應用於整個數據集。 |
+| `route_id`          | 國外身份證參考`routes.route_id`  | 可選的     | 功能同上`agency_id`除非屬性適用於路線。多個屬性可能適用於同一路線。 |
+| `trip_id`           | 國外身份證參考`trips.trip_id`    | 可選的     | 功能同上`agency_id`除非歸因適用於旅行。多個歸因可能適用於同一次旅行。 |
+| `organization_name` | 文本                        | **必需的** | 數據集所屬的組織的名稱。 |
+| `is_producer`       | 枚舉                        | 可選的     | 組織的角色是生產者。有效的選項是：<br/><br/>`0`或為空 - 組織沒有此角色。 <br/>`1` - 組織確實有這個角色。 <br/><br/>至少其中一個字段`is_producer` ,`is_operator`， 或者`is_authority`應該設置在`1` . |
+| `is_operator`       | 枚舉                        | 可選的     | 功能同上`is_producer`除了組織的角色是操作員。 |
+| `is_authority`      | 枚舉                        | 可選的     | 功能同上`is_producer`除了組織的作用是權威。 |
+| `attribution_url`   | 網址                        | 可選的     | 組織的 URL。 |
+| `attribution_email` | 電子郵件                      | 可選的     | 組織的電子郵件。 |
+| `attribution_phone` | 電話號碼                      | 可選的     | 組織的電話號碼。 |


### PR DESCRIPTION
I was taking a look at the gtfs.org website translations, and noticed that the traditional Chinese translation was actually using simplified characters in a large portion of the translation.