### PR TITLE
replace OpenMobilityData with Mobility Database

### DIFF
--- a/docs/schedule/examples/index.md
+++ b/docs/schedule/examples/index.md
@@ -17,4 +17,4 @@ To help in understanding the GTFS specification and in producing tools that read
     - [Translations](translations)
     - [Feed information](feed-info)
     - [Dataset attributions](attributions)
-- See [OpenMobilityData](https://openmobilitydata.org/) for public feeds from real transit agencies.
+- See the [Mobility Database](https://database.mobilitydata.org/) for public feeds from real transit agencies.


### PR DESCRIPTION
OpenMobilityData links should be replaced with links to the Mobility Database