### PR TITLE
Fix Typo in stops.txt example

### DIFF
--- a/docs/schedule/examples/routes-stops-trips.md
+++ b/docs/schedule/examples/routes-stops-trips.md
@@ -48,7 +48,7 @@ In GTFS, stops and stations are described using the file [stops.txt](../../refer
 ```
 stop_id,stop_code,stop_name,stop_lat,stop_lon,location_type
 8157,8157,44th Avenue NE (SB),51.091106,-113.958565,0
-6810,6810,NB Marlborough CTrain Station,51.058990,-113.981582,0
+6810,6810,NB Marlborough CTrain Station,51.058990,-113.981582,1
 ```
 
 - `stop_id` is a unique identifier


### PR DESCRIPTION
The description says the second record has `location_type=1` but it is `0` in the example.