### PR TITLE
feat: Announce fare media vote

### DIFF
--- a/docs/extensions/fares-v2.de.md
+++ b/docs/extensions/fares-v2.de.md
@@ -32,7 +32,7 @@ Hersteller können Tarif v2 im gleichen Datensatz wie Tarif v1 implementieren, d
 
 Der Vorschlag für Tarifmedien (früher Tarifcontainer) wurde zur Abstimmung aufgerufen!
 
-[Stimmt im GitHub Pull Request vor dem 23. Februar 11:00pm UTC ab.](https://github.com/google/transit/pull/355#issuecomment-1430617967)
+[Stimmt im GitHub Pull Request vor dem 13. März 23:59:59 UTC ab.](https://github.com/google/transit/pull/355#issuecomment-1456392466)
 
 <a class="button no-icon" href="https://share.mobilitydata.org/slack" target="_blank">Treten Sie #gtfs-fares auf Slack bei</a><a class="button no-icon" href="https://www.eventbrite.ca/e/specifications-discussions-gtfs-fares-v2-monthly-meetings-tickets-522966225057" target="_blank">Siehe den Sitzungsplan</a><a class="button no-icon" href="https://docs.google.com/document/d/1d3g5bMXupdElCKrdv6rhFNN11mrQgEk-ibA7wdqVLTU/edit" target="_blank">Siehe Sitzungsnotizen</a>
 
@@ -45,7 +45,7 @@ Bei der angenommenen Basisimplementierung waren die Erstanwender
 - Produzenten: [Interline](https://www.interline.io/), [Maryland Department of Transportation](https://www.mta.maryland.gov/developer-resources), [Cal-ITP](https://dot.ca.gov/cal-itp/cal-itp-gtfs)
 - Verbraucher: [Transit](https://transitapp.com/)
 
-Für die derzeit diskutierte Funktion der Fahrpreiscontainer sind die Erstanwender
+Für die derzeit diskutierte Funktion der fare media sind die Erstanwender
 
 - Produzent: [Interline](https://www.interline.io/)
 - Verbraucher: [Apple](https://www.apple.com/), [Transit](https://transitapp.com/)

--- a/docs/extensions/fares-v2.de.md
+++ b/docs/extensions/fares-v2.de.md
@@ -30,12 +30,9 @@ Hersteller können Tarif v2 im gleichen Datensatz wie Tarif v1 implementieren, d
 
 ## Laufende Arbeiten zu Fares v2
 
-Die GTFS-Gemeinschaft arbeitet derzeit an der Fertigstellung des Vorschlags für [Tarifcontainer](https://share.mobilitydata.org/fare-containers-to-fare-payment-types-proposal).
+Der Vorschlag für Tarifmedien (früher Tarifcontainer) wurde zur Abstimmung aufgerufen!
 
-Folgende Punkte werden derzeit diskutiert:
-
-- Erstellung einer Tarif-Container-Datei
-- Abstimmung darüber, welche Typen in die Aufzählung der Tarifcontainer-Optionen aufgenommen werden sollen
+[Stimmt im GitHub Pull Request vor dem 23. Februar 11:00pm UTC ab.](https://github.com/google/transit/pull/355#issuecomment-1430617967)
 
 <a class="button no-icon" href="https://share.mobilitydata.org/slack" target="_blank">Treten Sie #gtfs-fares auf Slack bei</a><a class="button no-icon" href="https://www.eventbrite.ca/e/specifications-discussions-gtfs-fares-v2-monthly-meetings-tickets-522966225057" target="_blank">Siehe den Sitzungsplan</a><a class="button no-icon" href="https://docs.google.com/document/d/1d3g5bMXupdElCKrdv6rhFNN11mrQgEk-ibA7wdqVLTU/edit" target="_blank">Siehe Sitzungsnotizen</a>
 

--- a/docs/extensions/fares-v2.es.md
+++ b/docs/extensions/fares-v2.es.md
@@ -32,7 +32,7 @@ Los productores pueden implementar Fares v2 en el mismo conjunto de datos que Fa
 
 La propuesta de fare media (antes fare containers) ha sido sometida a votación.
 
-[Vota en el pull request de GitHub antes del 23 de febrero a las 23:00 UTC.](https://github.com/google/transit/pull/355#issuecomment-1430617967)
+[Vota en el pull request de GitHub antes del 13 de marzo a las 23:59:59 UTC.](https://github.com/google/transit/pull/355#issuecomment-1456392466)
 
 <a class="button no-icon" href="https://share.mobilitydata.org/slack" target="_blank">Únase a #gtfs-fares en Slack</a><a class="button no-icon" target="_blank" href="https://www.eventbrite.ca/e/specifications-discussions-gtfs-fares-v2-monthly-meetings-tickets-522966225057">Vea el calendario de reuniones</a><a  class="button no-icon" target="_blank" href="https://docs.google.com/document/d/1d3g5bMXupdElCKrdv6rhFNN11mrQgEk-ibA7wdqVLTU/edit">Vea las notas de la reunión</a>.
 
@@ -45,10 +45,10 @@ En el caso de la implementación básica adoptada, los primeros en adoptarla fue
 - Productores: [Interline](https://www.interline.io/), [Maryland Department of Transportation](https://www.mta.maryland.gov/developer-resources), [Cal-ITP](https://dot.ca.gov/cal-itp/cal-itp-gtfs)
 - Consumidores: [Transit](https://transitapp.com/)
 
-Para la función de contenedores de tarifas actualmente en discusión, los primeros en adoptarla son
+Para la función de fare media actualmente en discusión, los primeros en adoptarla son
 
-- Productores: [Interline](https://www.interline.io/)
-- Consumidores: [Apple](https://www.apple.com/), [Transit](https://transitapp.com/)
+- Productores: [Interline](https://www.interline.io/), [Cal-ITP](https://dot.ca.gov/cal-itp/cal-itp-gtfs)
+- Consumidores: [Apple](https://www.apple.com/)
 
 <a class="button no-icon" target="_blank" href="https://docs.google.com/spreadsheets/d/1jpKjz6MbCD2XPhmIP11EDi-P2jMh7x2k-oHS-pLf2vI/edit?usp=sharing">Vea quién utiliza los archivos y campos de Fares v2</a>
 

--- a/docs/extensions/fares-v2.es.md
+++ b/docs/extensions/fares-v2.es.md
@@ -30,12 +30,9 @@ Los productores pueden implementar Fares v2 en el mismo conjunto de datos que Fa
 
 ## Trabajo en curso sobre Fares v2
 
-La comunidad GTFS está trabajando actualmente en la finalización de la propuesta de [contenedores de tarifas](https://share.mobilitydata.org/fare-containers-to-fare-payment-types-proposal).
+La propuesta de fare media (antes fare containers) ha sido sometida a votación.
 
-Entre los puntos actualmente en discusión figuran
-
-- Creación de un archivo de contenedores de tarifas
-- Alineación de los tipos que deben incluirse en la enumeración de opciones de contenedores de tarifas.
+[Vota en el pull request de GitHub antes del 23 de febrero a las 23:00 UTC.](https://github.com/google/transit/pull/355#issuecomment-1430617967)
 
 <a class="button no-icon" href="https://share.mobilitydata.org/slack" target="_blank">Únase a #gtfs-fares en Slack</a><a class="button no-icon" target="_blank" href="https://www.eventbrite.ca/e/specifications-discussions-gtfs-fares-v2-monthly-meetings-tickets-522966225057">Vea el calendario de reuniones</a><a  class="button no-icon" target="_blank" href="https://docs.google.com/document/d/1d3g5bMXupdElCKrdv6rhFNN11mrQgEk-ibA7wdqVLTU/edit">Vea las notas de la reunión</a>.
 

--- a/docs/extensions/fares-v2.fr.md
+++ b/docs/extensions/fares-v2.fr.md
@@ -30,12 +30,9 @@ Les producteurs peuvent mettre en œuvre Fares v2 dans le même ensemble de donn
 
 ## Travail en cours sur Fares v2
 
-La communauté GTFS travaille actuellement à la finalisation de la proposition de [conteneurs tarifaires](https://share.mobilitydata.org/fare-containers-to-fare-payment-types-proposal).
+La proposition fare media (anciennement fare containers) a été appelée à un vote !
 
-Les points actuellement en discussion incluent :
-
-- La création d'un fichier de conteneurs tarifaires
-- Alignement sur les types qui devraient être inclus dans l'énumération des options de conteneurs tarifaires.
+[Votez dans la demande de retrait GitHub avant le 23 février 23h00 UTC.](https://github.com/google/transit/pull/355#issuecomment-1430617967)
 
 <a class="button no-icon" target="_blank" href="https://share.mobilitydata.org/slack">Rejoignez #gtfs-fares sur Slack</a> 
 <a class="button no-icon" target="_blank" href="https://www.eventbrite.ca/e/specifications-discussions-gtfs-fares-v2-monthly-meetings-tickets-522966225057">Voir le programme des réunions</a>

--- a/docs/extensions/fares-v2.fr.md
+++ b/docs/extensions/fares-v2.fr.md
@@ -32,7 +32,7 @@ Les producteurs peuvent mettre en œuvre Fares v2 dans le même ensemble de donn
 
 La proposition fare media (anciennement fare containers) a été appelée à un vote !
 
-[Votez dans la demande de retrait GitHub avant le 23 février 23h00 UTC.](https://github.com/google/transit/pull/355#issuecomment-1430617967)
+[Votez dans la demande de retrait GitHub avant le 13 mars 23:59:59 UTC.](https://github.com/google/transit/pull/355#issuecomment-1456392466)
 
 <a class="button no-icon" target="_blank" href="https://share.mobilitydata.org/slack">Rejoignez #gtfs-fares sur Slack</a> 
 <a class="button no-icon" target="_blank" href="https://www.eventbrite.ca/e/specifications-discussions-gtfs-fares-v2-monthly-meetings-tickets-522966225057">Voir le programme des réunions</a>
@@ -47,10 +47,10 @@ Pour l'implémentation de base adoptée, les premiers adoptants étaient
 - Producteurs : [Interline](https://www.interline.io/), [Maryland Department of Transportation](https://www.mta.maryland.gov/developer-resources), [Cal-ITP](https://dot.ca.gov/cal-itp/cal-itp-gtfs)
 - Consommateur : [Transit](https://transitapp.com/)
 
-Pour la fonctionnalité de conteneurs tarifaires actuellement en discussion, les premiers adoptants sont
+Pour la fonctionnalité de fare media actuellement en discussion, les premiers adoptants sont
 
-- Producteur : [Interline](https://www.interline.io/)
-- Consommateur : [Apple](https://www.apple.com/), [Transit](https://transitapp.com/)
+- Producteur : [Interline](https://www.interline.io/), [Cal-ITP](https://dot.ca.gov/cal-itp/cal-itp-gtfs)
+- Consommateur : [Apple](https://www.apple.com/)
 
 <a class="button no-icon" target="_blank" href="https://docs.google.com/spreadsheets/d/1jpKjz6MbCD2XPhmIP11EDi-P2jMh7x2k-oHS-pLf2vI/edit?usp=sharing">Voir qui utilise les fichiers et les champs de Fares v2</a>
 

--- a/docs/extensions/fares-v2.id.md
+++ b/docs/extensions/fares-v2.id.md
@@ -30,7 +30,7 @@ Produsen dapat mengimplementasikan Fares v2 dalam kumpulan data yang sama dengan
 
 Proposal media tarif (sebelumnya wadah tarif) telah dipanggil untuk pemungutan suara!
 
-[Berikan suara pada pull request GitHub sebelum 23 Februari pukul 23:00 UTC.](https://github.com/google/transit/pull/355#issuecomment-1430617967)
+[Berikan suara pada pull request GitHub sebelum 13 Berbaris pukul 23:59:59 UTC.](https://github.com/google/transit/pull/355#issuecomment-1456392466)
 
 <a class="button no-icon" href="https://share.mobilitydata.org/slack" target="_blank">Bergabunglah dengan #gtfs-fares di Slack</a> <a class="button no-icon" href="https://www.eventbrite.ca/e/specifications-discussions-gtfs-fares-v2-monthly-meetings-tickets-522966225057" target="_blank">Lihat jadwal</a> <a class="button no-icon" href="https://docs.google.com/document/d/1d3g5bMXupdElCKrdv6rhFNN11mrQgEk-ibA7wdqVLTU/edit" target="_blank">rapat Lihat catatan rapat</a>
 
@@ -43,10 +43,10 @@ Untuk implementasi dasar yang diadopsi, pengadopsi pertama adalah
 - Produser: [Interline](https://www.interline.io/) , [Maryland Department of Transportation](https://www.mta.maryland.gov/developer-resources) , [Cal-ITP](https://dot.ca.gov/cal-itp/cal-itp-gtfs)
 - Konsumen: [Transit](https://transitapp.com/)
 
-Untuk fitur kontainer tarif yang saat ini sedang dibahas, pengadopsi pertama adalah
+Untuk fitur fare media yang saat ini sedang dibahas, pengadopsi pertama adalah
 
-- Produser: [Interline](https://www.interline.io/)
-- Konsumen: [Apple](https://www.apple.com/) , [Transit](https://transitapp.com/)
+- Produser: [Interline](https://www.interline.io/), [Cal-ITP](https://dot.ca.gov/cal-itp/cal-itp-gtfs)
+- Konsumen: [Apple](https://www.apple.com/)
 
 <a class="button no-icon" href="https://docs.google.com/spreadsheets/d/1jpKjz6MbCD2XPhmIP11EDi-P2jMh7x2k-oHS-pLf2vI/edit?usp=sharing" target="_blank">Lihat siapa yang menggunakan file dan bidang Fares v2</a>
 

--- a/docs/extensions/fares-v2.id.md
+++ b/docs/extensions/fares-v2.id.md
@@ -28,12 +28,9 @@ Produsen dapat mengimplementasikan Fares v2 dalam kumpulan data yang sama dengan
 
 ## Sedang Berlangsung Fares v2 Kerja
 
-Komunitas GTFS saat ini sedang menyelesaikan proposal [kontainer tarif](https://share.mobilitydata.org/fare-containers-to-fare-payment-types-proposal) .
+Proposal media tarif (sebelumnya wadah tarif) telah dipanggil untuk pemungutan suara!
 
-Hal-hal yang sedang didiskusikan antara lain:
-
-- Membuat file wadah ongkos
-- Menyelaraskan pada jenis apa yang harus dimasukkan dalam pencacahan opsi peti kemas tarif
+[Berikan suara pada pull request GitHub sebelum 23 Februari pukul 23:00 UTC.](https://github.com/google/transit/pull/355#issuecomment-1430617967)
 
 <a class="button no-icon" href="https://share.mobilitydata.org/slack" target="_blank">Bergabunglah dengan #gtfs-fares di Slack</a> <a class="button no-icon" href="https://www.eventbrite.ca/e/specifications-discussions-gtfs-fares-v2-monthly-meetings-tickets-522966225057" target="_blank">Lihat jadwal</a> <a class="button no-icon" href="https://docs.google.com/document/d/1d3g5bMXupdElCKrdv6rhFNN11mrQgEk-ibA7wdqVLTU/edit" target="_blank">rapat Lihat catatan rapat</a>
 

--- a/docs/extensions/fares-v2.ja.md
+++ b/docs/extensions/fares-v2.ja.md
@@ -30,12 +30,9 @@ Fares v1と技術的な矛盾がないため、制作者はFares v1と同じデ�
 
 ## 進行中のFares v2作業
 
-GTFSコミュニティは、現在、[運賃コンテナ](https://share.mobilitydata.org/fare-containers-to-fare-payment-types-proposal)提案の最終化に取り組んでいます。
+運賃メディア(旧運賃コンテナ)の提案が投票にかけられました!
 
-現在議論されている項目は以下の通りです。
-
-- 運賃コンテナファイルの作成
-- 運賃コンテナオプションの列挙にどのようなタイプを含めるべきかの整合性
+[2月23日23:00UTCまでにGitHubのプルリクエストで投票をお願いします。](https://github.com/google/transit/pull/355#issuecomment-1430617967)
 
 <a class="button no-icon" target="_blank" href="https://share.mobilitydata.org/slack">Slack の #gtfs-fares に参加する</a><a class="button no-icon" target="_blank" href="https://www.eventbrite.ca/e/specifications-discussions-gtfs-fares-v2-monthly-meetings-tickets-522966225057">ミーティングスケジュールを</a><a class="button no-icon" target="_blank" href="https://docs.google.com/document/d/1d3g5bMXupdElCKrdv6rhFNN11mrQgEk-ibA7wdqVLTU/edit">見るミーティングノートを見る</a>
 

--- a/docs/extensions/fares-v2.ja.md
+++ b/docs/extensions/fares-v2.ja.md
@@ -32,7 +32,7 @@ Fares v1と技術的な矛盾がないため、制作者はFares v1と同じデ�
 
 運賃メディア(旧運賃コンテナ)の提案が投票にかけられました!
 
-[2月23日23:00UTCまでにGitHubのプルリクエストで投票をお願いします。](https://github.com/google/transit/pull/355#issuecomment-1430617967)
+[3月13日23:59:59UTCまでにGitHubのプルリクエストで投票をお願いします。](https://github.com/google/transit/pull/355#issuecomment-1456392466)
 
 <a class="button no-icon" target="_blank" href="https://share.mobilitydata.org/slack">Slack の #gtfs-fares に参加する</a><a class="button no-icon" target="_blank" href="https://www.eventbrite.ca/e/specifications-discussions-gtfs-fares-v2-monthly-meetings-tickets-522966225057">ミーティングスケジュールを</a><a class="button no-icon" target="_blank" href="https://docs.google.com/document/d/1d3g5bMXupdElCKrdv6rhFNN11mrQgEk-ibA7wdqVLTU/edit">見るミーティングノートを見る</a>
 
@@ -45,10 +45,10 @@ Fares v1と技術的な矛盾がないため、制作者はFares v1と同じデ�
 - プロデューサーの皆さん[Interline](https://www.interline.io/)、[Maryland Department of Transportation](https://www.mta.maryland.gov/developer-resources)、[Cal-ITP](https://dot.ca.gov/cal-itp/cal-itp-gtfs)
 - 消費者[Transit](https://transitapp.com/)
 
-現在議論されている運賃コンテナ機能については、ファーストアダプターは以下の通りです。
+現在議論されているfare mediaナ機能については、ファーストアダプターは以下の通りです。
 
-- 生産者[Interline](https://www.interline.io/)
-- 消費者[Apple](https://www.apple.com/)、[Transit](https://transitapp.com/)
+- 生産者[Interline](https://www.interline.io/)、 [Cal-ITP](https://dot.ca.gov/cal-itp/cal-itp-gtfs)
+- 消費者[Apple](https://www.apple.com/)
 
 <a class="button no-icon" target="_blank" href="https://docs.google.com/spreadsheets/d/1jpKjz6MbCD2XPhmIP11EDi-P2jMh7x2k-oHS-pLf2vI/edit?usp=sharing">Fares v2ファイルおよびフィールドの使用者を見る</a>
 

--- a/docs/extensions/fares-v2.ko.md
+++ b/docs/extensions/fares-v2.ko.md
@@ -28,12 +28,9 @@ Fares v2가 나타낼 주요 개념은 다음과 같습니다.
 
 ## 진행 중인 운임 v2 작업
 
-GTFS 커뮤니티는 현재 [운임 컨테이너](https://share.mobilitydata.org/fare-containers-to-fare-payment-types-proposal) 제안을 마무리하기 위해 노력하고 있습니다.
+운임 매체(이전 운임 컨테이너) 제안이 투표에 부름 받았습니다!
 
-현재 논의 중인 항목은 다음과 같습니다.
-
-- 운임 컨테이너 파일 생성
-- 운임 컨테이너 옵션의 목록에 포함되어야 하는 유형 조정
+[2월 23일 오후 11시(UTC) 이전에 GitHub 풀 리퀘스트에 투표하세요.](https://github.com/google/transit/pull/355#issuecomment-1430617967)
 
 <a class="button no-icon" target="_blank" href="https://share.mobilitydata.org/slack">Slack에서 #gtfs-fares 가입</a> <a class="button no-icon" target="_blank" href="https://www.eventbrite.ca/e/specifications-discussions-gtfs-fares-v2-monthly-meetings-tickets-522966225057">회의 일정</a><a class="button no-icon" target="_blank" href="https://docs.google.com/document/d/1d3g5bMXupdElCKrdv6rhFNN11mrQgEk-ibA7wdqVLTU/edit">보기 회의 메모 보기</a>
 

--- a/docs/extensions/fares-v2.ko.md
+++ b/docs/extensions/fares-v2.ko.md
@@ -30,7 +30,7 @@ Fares v2가 나타낼 주요 개념은 다음과 같습니다.
 
 운임 매체(이전 운임 컨테이너) 제안이 투표에 부름 받았습니다!
 
-[2월 23일 오후 11시(UTC) 이전에 GitHub 풀 리퀘스트에 투표하세요.](https://github.com/google/transit/pull/355#issuecomment-1430617967)
+[3월 13일 23:59:59 UTC 이전에 GitHub 풀 요청에 투표하세요.](https://github.com/google/transit/pull/355#issuecomment-1456392466)
 
 <a class="button no-icon" target="_blank" href="https://share.mobilitydata.org/slack">Slack에서 #gtfs-fares 가입</a> <a class="button no-icon" target="_blank" href="https://www.eventbrite.ca/e/specifications-discussions-gtfs-fares-v2-monthly-meetings-tickets-522966225057">회의 일정</a><a class="button no-icon" target="_blank" href="https://docs.google.com/document/d/1d3g5bMXupdElCKrdv6rhFNN11mrQgEk-ibA7wdqVLTU/edit">보기 회의 메모 보기</a>
 
@@ -43,10 +43,10 @@ Fares v2가 나타낼 주요 개념은 다음과 같습니다.
 - 생산자: [Interline](https://www.interline.io/) , [Maryland Department of Transportation](https://www.mta.maryland.gov/developer-resources) , [Cal-ITP](https://dot.ca.gov/cal-itp/cal-itp-gtfs)
 - 소비자: [Transit](https://transitapp.com/)
 
-현재 논의 중인 운임 컨테이너 기능의 경우 최초 채택자는 다음과 같습니다.
+현재 논의 중인 운임 fare media 기능의 경우 최초 채택자는 다음과 같습니다.
 
-- 제작사 : [Interline](https://www.interline.io/)
-- 소비자: [Apple](https://www.apple.com/) , [Transit](https://transitapp.com/)
+- 제작사 : [Interline](https://www.interline.io/), [Cal-ITP](https://dot.ca.gov/cal-itp/cal-itp-gtfs)
+- 소비자: [Apple](https://www.apple.com/)
 
 <a class="button no-icon" target="_blank" href="https://docs.google.com/spreadsheets/d/1jpKjz6MbCD2XPhmIP11EDi-P2jMh7x2k-oHS-pLf2vI/edit?usp=sharing">누가 Fares v2 파일 및 필드를 사용하는지 확인</a>
 

--- a/docs/extensions/fares-v2.md
+++ b/docs/extensions/fares-v2.md
@@ -30,12 +30,9 @@ Producers may implement Fares v2 in the same dataset with Fares v1, since there 
 
 ## In Progress Fares v2 Work
 
-The GTFS community is currently working on finalizing the <a href="https://share.mobilitydata.org/fare-containers-to-fare-payment-types-proposal" target="_blank">fare containers</a> proposal. 
-    
-Items currently in discussion include:
+The fare media (formerly fare containers) proposal has been called to a vote! 
 
-- Creating a fare containers file
-- Aligning on what types should be included in the enumeration for fare container options
+<a href="https://github.com/google/transit/pull/355#issuecomment-1430617967" target="_blank">Vote in the GitHub pull request before February 23rd 11:00pm UTC.</a>
 
 <a class="button no-icon" href=https://share.mobilitydata.org/slack>Join #gtfs-fares on Slack</a><a class="button no-icon" href=https://www.eventbrite.ca/e/specifications-discussions-gtfs-fares-v2-monthly-meetings-tickets-522966225057>See the meeting schedule</a><a class="button no-icon" href=https://docs.google.com/document/d/1d3g5bMXupdElCKrdv6rhFNN11mrQgEk-ibA7wdqVLTU/edit>See meeting notes</a>
 

--- a/docs/extensions/fares-v2.md
+++ b/docs/extensions/fares-v2.md
@@ -32,7 +32,7 @@ Producers may implement Fares v2 in the same dataset with Fares v1, since there 
 
 The fare media (formerly fare containers) proposal has been called to a vote! 
 
-<a href="https://github.com/google/transit/pull/355#issuecomment-1430617967" target="_blank">Vote in the GitHub pull request before February 23rd 11:00pm UTC.</a>
+<a href="https://github.com/google/transit/pull/355#issuecomment-1456392466" target="_blank">Vote in the GitHub pull request before 2023-03-13 at 23:59:59 UTC.</a>
 
 <a class="button no-icon" href=https://share.mobilitydata.org/slack>Join #gtfs-fares on Slack</a><a class="button no-icon" href=https://www.eventbrite.ca/e/specifications-discussions-gtfs-fares-v2-monthly-meetings-tickets-522966225057>See the meeting schedule</a><a class="button no-icon" href=https://docs.google.com/document/d/1d3g5bMXupdElCKrdv6rhFNN11mrQgEk-ibA7wdqVLTU/edit>See meeting notes</a>
 
@@ -46,10 +46,10 @@ For the adopted base implementation, first adopters were
 - Producers: <a href="https://www.interline.io/" target="_blank">Interline</a>, <a href="https://www.mta.maryland.gov/developer-resources" target="_blank">Maryland Department of Transportation</a>, <a href="https://dot.ca.gov/cal-itp/cal-itp-gtfs" target="_blank">Cal-ITP</a>
 - Consumer: <a href="https://transitapp.com/" target="_blank">Transit</a>
 
-For the fare containers feature currently under discussion, first adopters are
+For the fare media feature currently under discussion, first adopters are
 
-- Producer: <a href="https://www.interline.io/" target="_blank">Interline</a>
-- Consumer: <a href="https://www.apple.com/">Apple</a>, <a href="https://transitapp.com/" target="_blank">Transit</a>
+- Producer: <a href="https://www.interline.io/" target="_blank">Interline</a>, [Cal-ITP](https://dot.ca.gov/cal-itp/cal-itp-gtfs)
+- Consumer: <a href="https://www.apple.com/">Apple</a>
 
 <a class="button no-icon" href="https://docs.google.com/spreadsheets/d/1jpKjz6MbCD2XPhmIP11EDi-P2jMh7x2k-oHS-pLf2vI/edit?usp=sharing" target="_blank">See who’s using Fares v2 files and fields</a>
 

--- a/docs/extensions/fares-v2.pt_BR.md
+++ b/docs/extensions/fares-v2.pt_BR.md
@@ -30,12 +30,9 @@ Os produtores podem implementar Fares v2 no mesmo conjunto de dados com Fares v1
 
 ## Fares em andamento v2 Trabalho
 
-A comunidade GTFS está atualmente trabalhando na finalização da proposta de [contêineres tarifários](https://share.mobilitydata.org/fare-containers-to-fare-payment-types-proposal).
+A proposta da mídia de tarifas (anteriormente contêineres tarifários) foi chamada para votação!
 
-Os itens atualmente em discussão incluem:
-
-- Criação de um arquivo de contêineres tarifários
-- Alinhamento sobre que tipos devem ser incluídos na enumeração de opções de contêineres tarifários
+[Votar no pedido de retirada do GitHub antes de 23 de fevereiro 23:00 UTC.](https://github.com/google/transit/pull/355#issuecomment-1430617967)
 
 <a class="button no-icon" target="_blank" href="https://share.mobilitydata.org/slack">Junte-se à #gtfs-fares no Slack</a><a class="button no-icon" target="_blank" href="https://www.eventbrite.ca/e/specifications-discussions-gtfs-fares-v2-monthly-meetings-tickets-522966225057">See a programação da reunião</a><a class="button no-icon" target="_blank" href="https://docs.google.com/document/d/1d3g5bMXupdElCKrdv6rhFNN11mrQgEk-ibA7wdqVLTU/edit">Veja as notas da reunião</a>
 

--- a/docs/extensions/fares-v2.pt_BR.md
+++ b/docs/extensions/fares-v2.pt_BR.md
@@ -32,7 +32,7 @@ Os produtores podem implementar Fares v2 no mesmo conjunto de dados com Fares v1
 
 A proposta da mídia de tarifas (anteriormente contêineres tarifários) foi chamada para votação!
 
-[Votar no pedido de retirada do GitHub antes de 23 de fevereiro 23:00 UTC.](https://github.com/google/transit/pull/355#issuecomment-1430617967)
+[Votar no pedido de retirada do GitHub antes de 13 de março 23:59:59 UTC.](https://github.com/google/transit/pull/355#issuecomment-1456392466)
 
 <a class="button no-icon" target="_blank" href="https://share.mobilitydata.org/slack">Junte-se à #gtfs-fares no Slack</a><a class="button no-icon" target="_blank" href="https://www.eventbrite.ca/e/specifications-discussions-gtfs-fares-v2-monthly-meetings-tickets-522966225057">See a programação da reunião</a><a class="button no-icon" target="_blank" href="https://docs.google.com/document/d/1d3g5bMXupdElCKrdv6rhFNN11mrQgEk-ibA7wdqVLTU/edit">Veja as notas da reunião</a>
 
@@ -45,10 +45,10 @@ Para a implementação da base adotada, os primeiros adotantes foram
 - Produtores: [Interline](https://www.interline.io/), [Maryland Department of Transportation](https://www.mta.maryland.gov/developer-resources), [Cal-ITP](https://dot.ca.gov/cal-itp/cal-itp-gtfs)
 - Consumidor: [Transit](https://transitapp.com/)
 
-Para os contêineres tarifários atualmente em discussão, os primeiros adotantes são
+Para os fare media atualmente em discussão, os primeiros adotantes são
 
-- Produtor: [Interline](https://www.interline.io/)
-- Consumidor: [Apple](https://www.apple.com/), [Transit](https://transitapp.com/)
+- Produtor: [Interline](https://www.interline.io/), [Cal-ITP](https://dot.ca.gov/cal-itp/cal-itp-gtfs)
+- Consumidor: [Apple](https://www.apple.com/)
 
 <a class="button no-icon" target="_blank" href="https://docs.google.com/spreadsheets/d/1jpKjz6MbCD2XPhmIP11EDi-P2jMh7x2k-oHS-pLf2vI/edit?usp=sharing">Veja quem está usando os arquivos e campos do Fares v2</a>
 

--- a/docs/extensions/fares-v2.ru.md
+++ b/docs/extensions/fares-v2.ru.md
@@ -30,12 +30,9 @@ Fares v2 - это проект расширения расписания GTFS, �
 
 ## Текущая работа над Fares v2
 
-В настоящее время сообщество GTFS работает над окончательной доработкой предложения по [тарифным контейнерам](https://share.mobilitydata.org/fare-containers-to-fare-payment-types-proposal).
+Предложение по fare media (ранее fare containers) было вынесено на голосование!
 
-В настоящее время обсуждаются следующие вопросы:
-
-- Создание файла контейнеров тарифов
-- Согласование того, какие типы должны быть включены в перечисление вариантов контейнеров для оплаты проезда.
+[Проголосуйте в GitHub pull request до 23 февраля 11:00 UTC.](https://github.com/google/transit/pull/355#issuecomment-1430617967)
 
 <a class="button no-icon" target="_blank" href="https://share.mobilitydata.org/slack">Присоединяйтесь к #gtfs-fares на Slack</a><a class="button no-icon" target="_blank" href="https://www.eventbrite.ca/e/specifications-discussions-gtfs-fares-v2-monthly-meetings-tickets-522966225057">Смотрите расписание встречСмотрите</a><a class="button no-icon" target="_blank" href="https://docs.google.com/document/d/1d3g5bMXupdElCKrdv6rhFNN11mrQgEk-ibA7wdqVLTU/edit">записи встреч</a>
 

--- a/docs/extensions/fares-v2.ru.md
+++ b/docs/extensions/fares-v2.ru.md
@@ -32,7 +32,7 @@ Fares v2 - это проект расширения расписания GTFS, �
 
 Предложение по fare media (ранее fare containers) было вынесено на голосование!
 
-[Проголосуйте в GitHub pull request до 23 февраля 11:00 UTC.](https://github.com/google/transit/pull/355#issuecomment-1430617967)
+[Проголосуйте в GitHub pull request до 13 март 23:59:59 UTC.](https://github.com/google/transit/pull/355#issuecomment-1456392466)
 
 <a class="button no-icon" target="_blank" href="https://share.mobilitydata.org/slack">Присоединяйтесь к #gtfs-fares на Slack</a><a class="button no-icon" target="_blank" href="https://www.eventbrite.ca/e/specifications-discussions-gtfs-fares-v2-monthly-meetings-tickets-522966225057">Смотрите расписание встречСмотрите</a><a class="button no-icon" target="_blank" href="https://docs.google.com/document/d/1d3g5bMXupdElCKrdv6rhFNN11mrQgEk-ibA7wdqVLTU/edit">записи встреч</a>
 
@@ -45,10 +45,10 @@ Fares v2 - это проект расширения расписания GTFS, �
 - Продюсеры: [Interline](https://www.interline.io/), [Maryland Department of Transportation](https://www.mta.maryland.gov/developer-resources), [Cal-ITP](https://dot.ca.gov/cal-itp/cal-itp-gtfs)
 - Потребители: [Тransit](https://transitapp.com/)
 
-Для функции контейнеров для оплаты проезда, которая в настоящее время обсуждается, первыми последователями были
+Для функции fare media, которая в настоящее время обсуждается, первыми последователями были
 
-- Производитель: [Interline](https://www.interline.io/)
-- Потребитель: [Apple](https://www.apple.com/), [Transit](https://transitapp.com/)
+- Производитель: [Interline](https://www.interline.io/), [Cal-ITP](https://dot.ca.gov/cal-itp/cal-itp-gtfs)
+- Потребитель: [Apple](https://www.apple.com/)
 
 <a class="button no-icon" target="_blank" href="https://docs.google.com/spreadsheets/d/1jpKjz6MbCD2XPhmIP11EDi-P2jMh7x2k-oHS-pLf2vI/edit?usp=sharing">Посмотрите, кто использует файлы и поля Fares v2</a>
 

--- a/docs/extensions/fares-v2.zh.md
+++ b/docs/extensions/fares-v2.zh.md
@@ -32,7 +32,7 @@ Fares v2计划体现的主要概念是
 
 票价媒体（以前的票价容器）提案已被要求进行表决
 
-[在2月23日11:00 UTC之前，请在GitHub拉动请求中投票。](https://github.com/google/transit/pull/355#issuecomment-1430617967)
+[在3月13日23:59:59 UTC之前，请在GitHub拉动请求中投票。](https://github.com/google/transit/pull/355#issuecomment-1456392466)
 
 <a class="button no-icon" target="_blank" href="https://share.mobilitydata.org/slack">在Slack上加入#gtfs-fares查看</a><a class="button no-icon" target="_blank" href="https://www.eventbrite.ca/e/specifications-discussions-gtfs-fares-v2-monthly-meetings-tickets-522966225057">会议时间表查看</a><a class="button no-icon" target="_blank" href="https://docs.google.com/document/d/1d3g5bMXupdElCKrdv6rhFNN11mrQgEk-ibA7wdqVLTU/edit">会议记录</a>
 
@@ -45,10 +45,10 @@ Fares v2计划体现的主要概念是
 - 生产者。[Interline](https://www.interline.io/)、[Maryland Department of Transportation](https://www.mta.maryland.gov/developer-resources)、[Cal-ITP](https://dot.ca.gov/cal-itp/cal-itp-gtfs)
 - 消费者。[Transit](https://transitapp.com/)
 
-对于目前正在讨论的票价容器功能，首先采用者是
+对于目前正在讨论fare media功能，首先采用者是
 
-- 生产者。[Interline](https://www.interline.io/)
-- 消费者。[Apple](https://www.apple.com/)、[Transit](https://transitapp.com/)
+- 生产者。[Interline](https://www.interline.io/), [Cal-ITP](https://dot.ca.gov/cal-itp/cal-itp-gtfs)
+- 消费者。[Apple](https://www.apple.com/)
 
 <a class="button no-icon" target="_blank" href="https://docs.google.com/spreadsheets/d/1jpKjz6MbCD2XPhmIP11EDi-P2jMh7x2k-oHS-pLf2vI/edit?usp=sharing">查看谁在使用Fares v2文件和字段</a>
 

--- a/docs/extensions/fares-v2.zh.md
+++ b/docs/extensions/fares-v2.zh.md
@@ -30,12 +30,9 @@ Fares v2计划体现的主要概念是
 
 ## 正在进行的Fares v2工作
 
-GTFS社区目前正致力于最终确定[票价容器](https://share.mobilitydata.org/fare-containers-to-fare-payment-types-proposal)提案。
+票价媒体（以前的票价容器）提案已被要求进行表决
 
-目前正在讨论的项目包括。
-
-- 创建一个票价容器文件
-- 就票价容器选项的列举中应包括哪些类型达成一致
+[在2月23日11:00 UTC之前，请在GitHub拉动请求中投票。](https://github.com/google/transit/pull/355#issuecomment-1430617967)
 
 <a class="button no-icon" target="_blank" href="https://share.mobilitydata.org/slack">在Slack上加入#gtfs-fares查看</a><a class="button no-icon" target="_blank" href="https://www.eventbrite.ca/e/specifications-discussions-gtfs-fares-v2-monthly-meetings-tickets-522966225057">会议时间表查看</a><a class="button no-icon" target="_blank" href="https://docs.google.com/document/d/1d3g5bMXupdElCKrdv6rhFNN11mrQgEk-ibA7wdqVLTU/edit">会议记录</a>
 

--- a/docs/extensions/fares-v2.zh_TW.md
+++ b/docs/extensions/fares-v2.zh_TW.md
@@ -28,12 +28,9 @@ Fares v2 計劃表達的主要概念是
 
 ## 進行中的票價 v2 工作
 
-GTFS 社區目前正在努力完成[票價容器](https://share.mobilitydata.org/fare-containers-to-fare-payment-types-proposal)提案。
+票價媒體（以前的票價容器）提案已被要求投票！
 
-目前正在討論的項目包括：
-
-- 創建票價容器文件
-- 調整哪些類型應包含在票價容器選項的枚舉中
+[在 UTC 時間 2 月 23 日晚上 11:00 之前在 GitHub 拉取請求中投票。](https://github.com/google/transit/pull/355#issuecomment-1430617967)
 
 <a class="button no-icon" target="_blank" href="https://share.mobilitydata.org/slack">在 Slack 上加入#gtfs-fares</a> <a class="button no-icon" target="_blank" href="https://www.eventbrite.ca/e/specifications-discussions-gtfs-fares-v2-monthly-meetings-tickets-522966225057">查看會議日程</a><a class="button no-icon" target="_blank" href="https://docs.google.com/document/d/1d3g5bMXupdElCKrdv6rhFNN11mrQgEk-ibA7wdqVLTU/edit">查看會議記錄</a>
 

--- a/docs/extensions/fares-v2.zh_TW.md
+++ b/docs/extensions/fares-v2.zh_TW.md
@@ -30,7 +30,7 @@ Fares v2 計劃表達的主要概念是
 
 票價媒體（以前的票價容器）提案已被要求投票！
 
-[在 UTC 時間 2 月 23 日晚上 11:00 之前在 GitHub 拉取請求中投票。](https://github.com/google/transit/pull/355#issuecomment-1430617967)
+[在 UTC 時間 3 月 13 日晚上 23:59:59 之前在 GitHub 拉取請求中投票。](https://github.com/google/transit/pull/355#issuecomment-1456392466)
 
 <a class="button no-icon" target="_blank" href="https://share.mobilitydata.org/slack">在 Slack 上加入#gtfs-fares</a> <a class="button no-icon" target="_blank" href="https://www.eventbrite.ca/e/specifications-discussions-gtfs-fares-v2-monthly-meetings-tickets-522966225057">查看會議日程</a><a class="button no-icon" target="_blank" href="https://docs.google.com/document/d/1d3g5bMXupdElCKrdv6rhFNN11mrQgEk-ibA7wdqVLTU/edit">查看會議記錄</a>
 
@@ -43,10 +43,10 @@ Fares v2 計劃表達的主要概念是
 - 生產商： [Interline](https://www.interline.io/) 、[Maryland Department of Transportation](https://www.mta.maryland.gov/developer-resources)、 [Cal-ITP](https://dot.ca.gov/cal-itp/cal-itp-gtfs)
 - 消費者：[Transit](https://transitapp.com/)
 
-對於目前正在討論的票價容器功能，第一批採用者是
+對於目前正在討論fare media功能，第一批採用者是
 
-- 生產商：[Interline](https://www.interline.io/)
-- 消費者：[Apple](https://www.apple.com/)、[Transit](https://transitapp.com/)
+- 生產商：[Interline](https://www.interline.io/), [Cal-ITP](https://dot.ca.gov/cal-itp/cal-itp-gtfs)
+- 消費者：[Apple](https://www.apple.com/)
 
 <a class="button no-icon" target="_blank" href="https://docs.google.com/spreadsheets/d/1jpKjz6MbCD2XPhmIP11EDi-P2jMh7x2k-oHS-pLf2vI/edit?usp=sharing">查看誰在使用 Fares v2 文件和字段</a>
 


### PR DESCRIPTION
This PR updates the "In progress" section of the Fares v2 extensions page so anyone going to the site will know that [a vote is open. ](https://github.com/google/transit/pull/355#issuecomment-1456392466)