### PR TITLE
fix: Update Mobility Database link on translated Schedule Examples index 

### DIFF
--- a/docs/schedule/examples/index.de.md
+++ b/docs/schedule/examples/index.de.md
@@ -19,4 +19,4 @@ Zum besseren Verständnis der GTFS und zur Erstellung von Tools, die GTFS lesen 
     - [Übersetzungen](translations)
     - [Informationen zur Einspeisung](feed-info)
     - [Datensatz-Attribute](attributions)
-- Siehe [OpenMobilityData](https://openmobilitydata.org/) für öffentliche Feeds von echten Verkehrsbetrieben.
+- Siehe [Mobility Database](https://database.mobilitydata.org/) für öffentliche Feeds von echten Verkehrsbetrieben.

--- a/docs/schedule/examples/index.es.md
+++ b/docs/schedule/examples/index.es.md
@@ -19,4 +19,4 @@ Para ayudar a entender la especificación GTFS y a producir herramientas que lea
     - [Traducciones](translations)
     - [Información sobre la alimentación](feed-info)
     - [Atribuciones del conjunto de datos](attributions)
-- Consulte [OpenMobilityData](https://openmobilitydata.org/) para ver los feeds públicos de las agencias de transporte reales.
+- Consulte [Mobility Database](https://database.mobilitydata.org/) para ver los feeds públicos de las agencias de transporte reales.

--- a/docs/schedule/examples/index.fr.md
+++ b/docs/schedule/examples/index.fr.md
@@ -19,4 +19,4 @@ Pour vous aider à comprendre la spécification GTFS et à produire des outils q
     - [Traductions](translations)
     - [Informations sur les flux](feed-info)
     - [Attribution des données](attributions)
-- Voir [OpenMobilityData](https://openmobilitydata.org/) pour les flux publics provenant d'agences de transport réelles.
+- Voir [Mobility Database](https://database.mobilitydata.org/) pour les flux publics provenant d'agences de transport réelles.

--- a/docs/schedule/examples/index.id.md
+++ b/docs/schedule/examples/index.id.md
@@ -19,4 +19,4 @@ Untuk membantu dalam memahami GTFS spesifikasi dan dalam memproduksi alat yang m
     - [Terjemahan](translations)
     - [Informasi umpan](feed-info)
     - [Atribusi set data](attributions)
-- Lihat [OpenMobilityData](https://openmobilitydata.org/) untuk umpan publik dari agen angkutan nyata.
+- Lihat [Mobility Database](https://database.mobilitydata.org/) untuk umpan publik dari agen angkutan nyata.

--- a/docs/schedule/examples/index.ja.md
+++ b/docs/schedule/examples/index.ja.md
@@ -19,4 +19,4 @@ GTFSの仕様を理解し、GTFSデータを読み書きするツールを作成
     - [翻訳](translations)
     - [フィード情報](feed-info)
     - [データセットの帰属](attributions)
-- 実際の交通機関が公開しているフィードについては、[OpenMobilityData](https://openmobilitydata.org/)を参照してください。
+- 実際の交通機関が公開しているフィードについては、[Mobility Database](https://database.mobilitydata.org/)を参照してください。

--- a/docs/schedule/examples/index.ko.md
+++ b/docs/schedule/examples/index.ko.md
@@ -19,4 +19,4 @@ search:
     - [번역](translations)
     - [피드 정보](feed-info)
     - [데이터세트 속성](attributions)
-- 실제 대중교통 기관의 공개 피드는 [OpenMobilityData](https://openmobilitydata.org/) 를 참조하십시오.
+- 실제 대중교통 기관의 공개 피드는 [Mobility Database](https://database.mobilitydata.org/) 를 참조하십시오.

--- a/docs/schedule/examples/index.pt_BR.md
+++ b/docs/schedule/examples/index.pt_BR.md
@@ -19,4 +19,4 @@ Para ajudar na compreensão da especificação GTFS e na produção de ferrament
     - [Traduções](translations)
     - [Informações sobre alimentação](feed-info)
     - [Atribuições do conjunto de dados](attributions)
-- Consulte [OpenMobilityData](https://openmobilitydata.org/) para obter informações públicas de agências de trânsito reais.
+- Consulte [Mobility Database](https://database.mobilitydata.org/) para obter informações públicas de agências de trânsito reais.

--- a/docs/schedule/examples/index.ru.md
+++ b/docs/schedule/examples/index.ru.md
@@ -19,4 +19,4 @@ search:
     - [Переводы](translations)
     - [Информация о фиде](feed-info)
     - [Атрибуты набора данных](attributions)
-- Смотрите [OpenMobilityData](https://openmobilitydata.org/) для публичных каналов от реальных транзитных агентств.
+- Смотрите [Mobility Database](https://database.mobilitydata.org/) для публичных каналов от реальных транзитных агентств.

--- a/docs/schedule/examples/index.zh.md
+++ b/docs/schedule/examples/index.zh.md
@@ -19,4 +19,4 @@ search:
     - [翻译](translations)
     - [饲料信息](feed-info)
     - [数据集属性](attributions)
-- 请参阅[OpenMobilityData](https://openmobilitydata.org/)，了解来自真实交通机构的公开信息。
+- 请参阅[Mobility Database](https://database.mobilitydata.org/)，了解来自真实交通机构的公开信息。

--- a/docs/schedule/examples/index.zh_TW.md
+++ b/docs/schedule/examples/index.zh_TW.md
@@ -19,4 +19,4 @@ search:
     - [翻譯](translations)
     - [飼料信息](feed-info)
     - [數據集屬性](attributions)
-- 請參閱[OpenMobilityData](https://openmobilitydata.org/) ，了解來自真實交通機構的公共信息。
+- 請參閱[Mobility Database](https://database.mobilitydata.org/)，了解來自真實交通機構的公共信息。


### PR DESCRIPTION
Update translated pages from #83 