### PR TITLE
Improve agency-facing information about GTFS and training resources

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,8 +8,44 @@
     <a class="button" href="schedule">GTFS Schedule</a><a class="button" href="realtime">GTFS Realtime</a><a class="button" href="resources">Resources</a><a class="button" href="extensions">Extensions</a>
 </div>
 
-The General Transit Feed Specification (GTFS) is a data specification that allows public transit agencies to publish their transit data in a format that can be consumed by a [wide variety of software applications](resources/apps). Today, the GTFS data format is used by thousands of public transport providers.
+The General Transit Feed Specification (GTFS) is an [Open Standard](https://www.interoperablemobility.org/definitions/#open_standard) used to distribute relevant information about transit systems to riders. It allows public transit agencies to publish their transit data in a format that can be consumed by a wide variety of software applications. Today, the GTFS data format is used by thousands of public transport providers.
 
-GTFS is split into a [schedule component](schedule) that contains schedule, fare, and geographic transit information and a [real-time component](realtime) that contains arrival predictions, vehicle positions and service advisories.
+GTFS is simple. Information about routes, schedules, and fares are represented in basic text files, which means it can be created and maintained without the use of complicated or proprietary software. It is split into a schedule component that contains schedule, fare, and geographic transit information and a real-time component that contains arrival predictions, vehicle positions and service advisories.
 
-[More GTFS background](background.md)
+GTFS is supported around the world and its use, importance, and scope has been increasing. It’s likely that an agency you know already uses GTFS to represent your routes, schedule, stop locations, and other information, and that riders are already consuming it via various applications.
+
+[Learn more about the history of GTFS](background.md)
+
+## Why Use GTFS?
+
+GTFS is used by over 10,000 transit agencies in over 100 countries. Most transit agencies have heard of GTFS, and it has quickly become an industry standard. Some agencies produce this data themselves, while others employ a vendor to create and maintain data for them. And because it is a simple, text-based Open Standard, many transit technology vendors can already read and write to GTFS files. By better understanding GTFS, you can make better choices when it comes to your data. The choices you make in how you maintain and distribute your GTFS can have a huge impact on the quality of service you’re able to provide.
+
+### Open Data means more opportunity and choices
+
+GTFS is an Open Standard. This means that you can make information available using any of the many tools which already support GTFS (including simple text editing using a text editor or a spreadsheet). Open standards lead to the creation of data that can be easily shared. A feed is simply the collection of text files that describe your service, hosted online at a permalink that’s publicly available. The same feed can be used by Google, Apple, Transit App, Open Trip Planner, and even apps created by riders. Anyone who wants to provide accurate and up-to-date transit information can use your GTFS to do so. 
+
+Some riders like to use different apps depending on their needs—having GTFS lets riders choose what trip planning app suits them best. Some apps may be more accessible or better at providing information for riders with disabilities, some may be simpler and easier to use, and sometimes riders just want the newest app.
+
+### GTFS can probably do more than you think
+
+GTFS is most widely known for trip planning information, particularly in metro areas with fixed-route service. However, there are a variety of optional features above and beyond the basic GTFS Schedule specification that make GTFS more widely applicable, including Fares for showing fare costs and structures, Flex (in development) for demand-responsive transit options, such as dial-a-ride and paratransit services, and Pathways for displaying accessibility information that’s vital to riders using mobility devices or needing additional accommodations. GTFS Realtime builds upon GTFS Schedule and on-vehicle GPS systems to provide real-time updates on vehicle locations.
+
+### GTFS is more than just trip planning
+
+GTFS data is now being used by a variety of software applications for many different purposes, including data visualization and analysis tools for planning. Having up-to-date and high quality data provides accurate transit information not just to riders, but to planners and policymakers who are able to better understand how transit is being used in their communities. Beginning in 2023, the Federal Transit Administration finalized its reporting changes to use GTFS as the mechanism to report geographic service area coverage to the National Transit Database (NTD). This means that [transit agencies must submit valid GTFS data](https://www.federalregister.gov/documents/2023/03/03/2023-04379/national-transit-database-reporting-changes-and-clarifications) with their annual NTD report along with their other reporting submissions.
+
+## What is High Quality GTFS
+
+High quality GTFS is complete, accurate, and up-to-date. This means that it represents how services are currently operating and provides as much information as possible.
+
+### Complete Data
+
+Quality GTFS includes important service details such as holiday and summer schedule changes, accurate stop locations, and names for routes and headsigns that match your other rider-facing materials. Even if an agency works with a vendor to produce GTFS, it’s ultimately up to your agency to ensure that the information you present in print, on board, and online is consistent.
+
+For information on creating high quality data, see the [California Transit Data Guidelines](https://dot.ca.gov/cal-itp/california-transit-data-guidelines) and the [GTFS Best Practices](https://gtfs.org/schedule/best-practices/)
+
+### Up to Date
+
+Having out of date data is almost worse than no feed at all. It's not enough to simply publish information—it has to match what the rider sees and experiences. Some of the largest transit agencies update their GTFS weekly, or even daily, but most agencies will need to update their GTFS every few months, or a few times a year when service changes. This includes things like new routes or stops, timetable changes, or updates to fare structure.
+ 
+Many agencies hire a vendor to create and manage their GTFS for them. Some vendors may be proactive in asking about service changes, but it’s important that agencies communicate with vendors about upcoming service changes. It’s possible to publish GTFS with service changes in advance, making sure the transition goes smoothly for everyone—agencies, vendors, trip planners, and riders!

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,19 +10,19 @@
 
 The General Transit Feed Specification (GTFS) is an [Open Standard](https://www.interoperablemobility.org/definitions/#open_standard) used to distribute relevant information about transit systems to riders. It allows public transit agencies to publish their transit data in a format that can be consumed by a wide variety of software applications. Today, the GTFS data format is used by thousands of public transport providers.
 
-GTFS is simple. Information about routes, schedules, and fares are represented in basic text files, which means it can be created and maintained without the use of complicated or proprietary software. It is split into a schedule component that contains schedule, fare, and geographic transit information and a real-time component that contains arrival predictions, vehicle positions and service advisories.
+GTFS is split into a schedule component that contains schedule, fare, and geographic transit information and a real-time component that contains arrival predictions, vehicle positions and service advisories. Information about routes, schedules, and fares are represented in basic text files, which means it can be created and maintained without the use of complicated or proprietary software.
 
-GTFS is supported around the world and its use, importance, and scope has been increasing. It’s likely that an agency you know already uses GTFS to represent your routes, schedule, stop locations, and other information, and that riders are already consuming it via various applications.
+GTFS is supported around the world and its use, importance, and scope has been increasing. It’s likely that an agency you know already uses GTFS to represent routes, schedule, stop locations, and other information, and that riders are already consuming it via various applications.
 
 [Learn more about the history of GTFS](background.md)
 
 ## Why Use GTFS?
 
-GTFS is used by over 10,000 transit agencies in over 100 countries. Most transit agencies have heard of GTFS, and it has quickly become an industry standard. Some agencies produce this data themselves, while others employ a vendor to create and maintain data for them. And because it is a simple, text-based Open Standard, many transit technology vendors can already read and write to GTFS files. By better understanding GTFS, you can make better choices when it comes to your data. The choices you make in how you maintain and distribute your GTFS can have a huge impact on the quality of service you’re able to provide.
+GTFS is used by over 10,000 transit agencies in over 100 countries. Most transit agencies have heard of GTFS, and it has quickly become an industry standard. Some agencies produce this data themselves, while others employ a vendor to create and maintain data for them. And because it is a simple, text-based Open Standard, many transit technology vendors can already read and write to GTFS files. By better understanding GTFS, agencies can make better choices when it comes to data. The choices agencies make in how to maintain and distribute GTFS can have a huge impact on service quality.
 
 ### Open Data means more opportunity and choices
 
-GTFS is an Open Standard. This means that you can make information available using any of the many tools which already support GTFS (including simple text editing using a text editor or a spreadsheet). Open standards lead to the creation of data that can be easily shared. A feed is simply the collection of text files that describe your service, hosted online at a permalink that’s publicly available. The same feed can be used by Google, Apple, Transit App, Open Trip Planner, and even apps created by riders. Anyone who wants to provide accurate and up-to-date transit information can use your GTFS to do so. 
+GTFS is an Open Standard. This means that agencies can make information available using any of the many tools which already support GTFS (including simple text editing using a text editor or a spreadsheet). Open standards lead to the creation of data that can be easily shared. A feed is simply the collection of text files that describe a service, hosted online at a permalink that’s publicly available. The same feed can be used by Google, Apple, Transit App, Open Trip Planner, and even apps created by riders. Anyone who wants to provide accurate and up-to-date transit information can use a GTFS feed to do so. 
 
 Some riders like to use different apps depending on their needs—having GTFS lets riders choose what trip planning app suits them best. Some apps may be more accessible or better at providing information for riders with disabilities, some may be simpler and easier to use, and sometimes riders just want the newest app.
 
@@ -32,7 +32,7 @@ GTFS is most widely known for trip planning information, particularly in metro a
 
 ### GTFS is more than just trip planning
 
-GTFS data is now being used by a variety of software applications for many different purposes, including data visualization and analysis tools for planning. Having up-to-date and high quality data provides accurate transit information not just to riders, but to planners and policymakers who are able to better understand how transit is being used in their communities. Beginning in 2023, the Federal Transit Administration finalized its reporting changes to use GTFS as the mechanism to report geographic service area coverage to the National Transit Database (NTD). This means that [transit agencies must submit valid GTFS data](https://www.federalregister.gov/documents/2023/03/03/2023-04379/national-transit-database-reporting-changes-and-clarifications) with their annual NTD report along with their other reporting submissions.
+GTFS data is now being used by a variety of software applications for many different purposes, including data visualization and analysis tools for planning. Having up-to-date and high quality data provides accurate transit information not just to riders, but to planners and policymakers who are able to better understand how transit is being used in their communities. Beginning in 2023, the United States' Federal Transit Administration will require [transit agencies there to submit valid GTFS data](https://www.federalregister.gov/documents/2023/03/03/2023-04379/national-transit-database-reporting-changes-and-clarifications) with their annual National Transit Database report.
 
 ## What is High Quality GTFS?
 
@@ -40,7 +40,7 @@ High quality GTFS is complete, accurate, and up-to-date. This means that it repr
 
 ### Complete Data
 
-Quality GTFS includes important service details such as holiday and summer schedule changes, accurate stop locations, and names for routes and headsigns that match your other rider-facing materials. Even if an agency works with a vendor to produce GTFS, it’s ultimately up to your agency to ensure that the information you present in print, on board, and online is consistent.
+Quality GTFS includes important service details such as holiday and summer schedule changes, accurate stop locations, and names for routes and headsigns that match other rider-facing materials. Even if an agency works with a vendor to produce GTFS, it’s ultimately up to the agency to ensure that the information presented in print, on board, and online is consistent.
 
 For information on creating high quality data, see the [California Transit Data Guidelines](https://dot.ca.gov/cal-itp/california-transit-data-guidelines) and the [GTFS Best Practices](https://gtfs.org/schedule/best-practices/)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,3 +49,5 @@ For information on creating high quality data, see the [California Transit Data 
 Having out of date data is almost worse than no feed at all. It's not enough to simply publish information—it has to match what the rider sees and experiences. Some of the largest transit agencies update their GTFS weekly, or even daily, but most agencies will need to update their GTFS every few months, or a few times a year when service changes. This includes things like new routes or stops, timetable changes, or updates to fare structure.
  
 Many agencies hire a vendor to create and manage their GTFS for them. Some vendors may be proactive in asking about service changes, but it’s important that agencies communicate with vendors about upcoming service changes. It’s possible to publish GTFS with service changes in advance, making sure the transition goes smoothly for everyone—agencies, vendors, trip planners, and riders!
+
+[Download this page as a printable PDF](https://share.mobilitydata.org/gtfs-intro-doc)

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ GTFS is most widely known for trip planning information, particularly in metro a
 
 GTFS data is now being used by a variety of software applications for many different purposes, including data visualization and analysis tools for planning. Having up-to-date and high quality data provides accurate transit information not just to riders, but to planners and policymakers who are able to better understand how transit is being used in their communities. Beginning in 2023, the Federal Transit Administration finalized its reporting changes to use GTFS as the mechanism to report geographic service area coverage to the National Transit Database (NTD). This means that [transit agencies must submit valid GTFS data](https://www.federalregister.gov/documents/2023/03/03/2023-04379/national-transit-database-reporting-changes-and-clarifications) with their annual NTD report along with their other reporting submissions.
 
-## What is High Quality GTFS
+## What is High Quality GTFS?
 
 High quality GTFS is complete, accurate, and up-to-date. This means that it represents how services are currently operating and provides as much information as possible.
 

--- a/docs/schedule/index.md
+++ b/docs/schedule/index.md
@@ -32,20 +32,24 @@ See “[Best Practices: Dataset Publishing](best-practices/#dataset-publishing-g
 <hr>
 
 **Technical details about GTFS, what it is, and how to create and maintain data:**
+
 - [GTFS Schedule Overview](https://gtfs.org/schedule/) 
 - [World Bank "Intro to GTFS" online course](https://olc.worldbank.org/content/introduction-general-transit-feed-specification-gtfs-and-informal-transit-system-mapping)
 - [MBTA GTFS Onboarding](https://mybinder.org/v2/gh/mbta/gtfs_onboarding/main?urlpath=lab/tree/GTFS_Onboarding.ipynb)
 
 **View example feeds with various features:**
+
 - [GTFS Mobility Database](https://database.mobilitydata.org/) 
 - [Transitland](https://www.transit.land/)
 
 **For free tools and instructional materials:**
+
 - [MobilityData GTFS Schedule Validator](https://gtfs-validator.mobilitydata.org/) 
 - [NRTAP lessons and GTFS Builder](https://www.nationalrtap.org/Technology-Tools/GTFS-Builder/Support)
 - [Arcadis IBI Data Tools](https://www.ibigroup.com/ibi-products/transit-data-tools/)
 
 **For ideas on vendors who offer GTFS services:**
+
 - [Center for Urban Transportation Research, University of South Florida List of GTFS Vendors](https://docs.google.com/spreadsheets/u/1/d/1Gc9mu4BIYC8ORpv2IbbVnT3q8VQ3xkeY7Hz068vT_GQ/pubhtml) 
 
 See more [online courses](../resources/other/#on-line-courses).

--- a/docs/schedule/index.md
+++ b/docs/schedule/index.md
@@ -28,20 +28,25 @@ The web-server hosting GTFS data should be configured to correctly report the fi
 
 See “[Best Practices: Dataset Publishing](best-practices/#dataset-publishing-general-practices)” for further recommendations.
 
-## Training
+## Training & Resources
 <hr>
 
-The World Bank Open Learning Campus (OLC) offers a self-based online course called “[Introduction to the General Transit Feed Specification (GTFS) and Informal Transit System Mapping](https://olc.worldbank.org/content/introduction-general-transit-feed-specification-gtfs-and-informal-transit-system-mapping)”. This course includes the following sections:
+**Technical details about GTFS, what it is, and how to create and maintain data:**
+- [GTFS Schedule Overview](https://gtfs.org/schedule/) 
+- [World Bank "Intro to GTFS" online course](https://olc.worldbank.org/content/introduction-general-transit-feed-specification-gtfs-and-informal-transit-system-mapping)
+- [MBTA GTFS Onboarding](https://mybinder.org/v2/gh/mbta/gtfs_onboarding/main?urlpath=lab/tree/GTFS_Onboarding.ipynb)
 
-- What is GTFS? History & File Structure
-- What is GTFS? Visualization & Community
-- Setting up a GTFS Feed
-- Introduction to GitHub & Open Source Tools
-- Stories from the Field
-- How to Map Transit Data
-- How to Collect Data for a City’s First Feed
-- App Survey
-- GTFS-Realtime
+**View example feeds with various features:**
+- [GTFS Mobility Database](https://database.mobilitydata.org/) 
+- [Transitland](https://www.transit.land/)
+
+**For free tools and instructional materials:**
+- [MobilityData GTFS Schedule Validator](https://gtfs-validator.mobilitydata.org/) 
+- [NRTAP lessons and GTFS Builder](https://www.nationalrtap.org/Technology-Tools/GTFS-Builder/Support)
+- [Arcadis IBI Data Tools](https://www.ibigroup.com/ibi-products/transit-data-tools/)
+
+**For ideas on vendors who offer GTFS services:**
+- [Center for Urban Transportation Research, University of South Florida List of GTFS Vendors](https://docs.google.com/spreadsheets/u/1/d/1Gc9mu4BIYC8ORpv2IbbVnT3q8VQ3xkeY7Hz068vT_GQ/pubhtml) 
 
 See more [online courses](../resources/other/#on-line-courses).
 


### PR DESCRIPTION
- Expand gtfs.org homepage to explain what GTFS is and why agencies might want it
- Expand Training section to include more resources

Per Cal-ITP initiative to improve quality and awareness of GTFS