### PR TITLE
Fix Images in Fares-v2 examples

### DIFF
--- a/docs/schedule/examples/fares-v2.md
+++ b/docs/schedule/examples/fares-v2.md
@@ -382,7 +382,7 @@ Alternatively, a user traveling in train #883 (`service_id=13`) would pay an Out
 
 In <a href="https://apple.com/maps" target="_blank">Apple Maps</a>, riders can see how their fare price changes and compare fare prices next to the train scheduled departure:
 
-<div class="time-variable_fare_photos">
+<div class="flex-photos">
     <img src="../../../assets/TimeVariableFares_Peak.png" alt="Outbound Adult Peak Zonal Fare of 20.00 USD">
     <img src="../../../assets/TimeVariableFares_OffPeak.png" alt="Outbound Adult Off Peak Zonal Fare of 15.00 USD">
 </div>


### PR DESCRIPTION
Formatting change to adjust image rendering size in time-variable fares example after changes made in PR #175 