### PR TITLE
Updated instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,21 +23,22 @@ We do accept glossary changes. Simpleen uses a glossary for key terms that are c
 ## Building the site locally
 
 1. In Terminal, change the directory to one where you wish to build the site.
-2. Clone this repository:
+1. Ensure you have an up-to-date version of pip:
+   - Linux: `pip install pip` or `pip install --upgrade pip`
+   - macOS: `pip3 install pip` or `pip3 install --upgrade pip`
+1. Clone this repository:
    - `git clone https://github.com/MobilityData/gtfs.org`
-3. Ensure you have an up-to-date version of pip:
-   - `pip install pip`
-   - N.B.: on macOS, use `pip3 install pip` when using Python 3.
-4. Change the directory to the cloned repository, and have [`requirements.txt`](requirements.txt) installed:
-   - `pip install -r requirements.txt`
-   - N.B.: on macOS, use `pip3 install -r requirements.txt` when using Python 3.
-5. Have [Material for MkDocs Insiders](https://squidfunk.github.io/mkdocs-material/insiders/`) installed. Substitute `${GH_TOKEN}` with MobilityData's access token:
-   - `pip install git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git`
-6. Assuming you are still in the cloned repository, run this command to update the content for the specification references and best practices:
+1. Change the directory to the cloned repository, and have [`requirements.txt`](requirements.txt) installed:
+   - Linux: `pip install --force-reinstall -r requirements.txt`
+   - macOS: `pip3 install --force-reinstall -r requirements.txt`
+1. Have [Material for MkDocs Insiders](https://squidfunk.github.io/mkdocs-material/insiders/`) installed. Substitute `${GH_TOKEN}` with MobilityData's access token:
+   - Linux: `pip install git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git`
+   - macOS: `pip3 install git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git`
+1. Assuming you are still in the cloned repository, run this command to update the content for the specification references and best practices:
    - `bash scripts/fetchdata.sh`
-7. To run the site locally: `mkdocs serve`
-8. To build the site locally only: `mkdocs build --clean`
-9. To deploy the site to GitHub Pages: `mkdocs gh-deploy`
+1. To run the site locally: `mkdocs serve`
+1. To build the site locally only: `mkdocs build --clean`
+1. To deploy the site to GitHub Pages: `mkdocs gh-deploy`
 
 ## License
 


### PR DESCRIPTION
* Changed to `pip install --force-reinstall -r requirements.txt` as it forces to reinstall all plugins, fixes an issue when old plugins remain and causes errors when building or serving the site.
* Changed order of the first 2 items.
* Specified which command is for linux and which is for macOS.