### PR TITLE
fix: deprecation warning for 2 Python Mkdown ext

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,8 +76,8 @@ markdown_extensions:
   - toc:
       permalink: true
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.tasklist:
       custom_checkbox: true
   - pymdownx.superfences


### PR DESCRIPTION
A deprecation warning was issued in MKdocs Material 9.4:
```
DeprecationWarning: 'materialx.emoji.to_svg' is deprecated. Material emoji logic 
has been officially moved into mkdocs-material version 9.4. 
Please use Material's 'material.extensions.emoji.to_svg' as mkdocs_material_extensions 
is deprecated and will no longer be supported moving forward. This is the last release.
```

This change fixes it, as defined in https://squidfunk.github.io/mkdocs-material/reference/icons-emojis/#configuration