### PR TITLE
Update version number on the Validate page

### DIFF
--- a/docs/schedule/validate.md
+++ b/docs/schedule/validate.md
@@ -9,7 +9,7 @@ This free and open-source canonical GTFS Schedule validator is maintained by [Mo
 <!-- <img class="center" src="../../assets/validator_animation.gif" width="150"> -->
 <br>
 
-[**Read the release notes for the latest version**](https://github.com/MobilityData/gtfs-validator/releases/latest)
+**Current version: 4.2** [(see the release notes)](https://github.com/MobilityData/gtfs-validator/releases/latest)
 
 <hr>
 

--- a/docs/schedule/validate.md
+++ b/docs/schedule/validate.md
@@ -9,7 +9,7 @@ This free and open-source canonical GTFS Schedule validator is maintained by [Mo
 <!-- <img class="center" src="../../assets/validator_animation.gif" width="150"> -->
 <br>
 
-**VERSION v4.1.0** / [Read the release notes](https://github.com/MobilityData/gtfs-validator/releases/latest)
+[**Read the release notes for the latest version**](https://github.com/MobilityData/gtfs-validator/releases/latest)
 
 <hr>
 


### PR DESCRIPTION
Removed the version number from this page so that we don't have to manually change it every time we have a release. 
The link to the latest release notes stays. 

cc @jcpitre