### PR TITLE
Fix broken link and add data examples on landing Schedule page

### DIFF
--- a/docs/schedule/index.md
+++ b/docs/schedule/index.md
@@ -33,7 +33,7 @@ See “[Best Practices: Dataset Publishing](best-practices/#dataset-publishing-g
 
 **Technical details about GTFS, what it is, and how to create and maintain data:**
 
-- [GTFS Schedule Overview](schedule/) 
+- [GTFS Schedule Overview](https://gtfs.org/schedule/reference/)
 - [World Bank "Intro to GTFS" online course](https://olc.worldbank.org/content/introduction-general-transit-feed-specification-gtfs-and-informal-transit-system-mapping)
 - [MBTA GTFS Onboarding](https://mybinder.org/v2/gh/mbta/gtfs_onboarding/main?urlpath=lab/tree/GTFS_Onboarding.ipynb)
 
@@ -41,6 +41,7 @@ See “[Best Practices: Dataset Publishing](best-practices/#dataset-publishing-g
 
 - [GTFS Mobility Database](https://database.mobilitydata.org/) 
 - [Transitland](https://www.transit.land/)
+- [Data examples](https://gtfs.org/schedule/examples/)
 
 **For free tools and instructional materials:**
 


### PR DESCRIPTION
In this PR: 

- fix a broken link
- add link to the data examples on the GTFS Schedule landing page