### PR TITLE
Add Publishing section

### DIFF
--- a/docs/schedule/index.md
+++ b/docs/schedule/index.md
@@ -5,7 +5,7 @@
 # GTFS Schedule Overview
 
 <div class="landing-page">
-    <a class="button" href="reference">Reference</a><a class="button" href="best-practices">Best Practices</a><a class="button" href="examples">Examples</a><a class="button" href="changes">Changes</a><a class="button" href="validate">Validate</a>
+    <a class="button" href="reference">Reference</a><a class="button" href="best-practices">Best Practices</a><a class="button" href="examples">Examples</a><a class="button" href="changes">Changes</a><a class="button" href="validate">Validate</a><a class="button" href="publish">Publish</a>
 </div>
 
 ## Getting Started

--- a/docs/schedule/publishing.md
+++ b/docs/schedule/publishing.md
@@ -71,7 +71,7 @@ In the event you have multiple GTFS datasets available to you—usually the resu
 
 ## Resources and Further Reading
 
-* [Best Practices for Publishing GTFS Data](http://gtfs.org/best-practices/#dataset-publishing--general-practices)
+* [Best Practices for Publishing GTFS Data](https://gtfs.org/schedule/reference/#dataset-publishing-general-practices)
 * [Applications and Uses for GTFS Data](http://gtfs.org/applications)
 * [Principles of Open Data](https://project-open-data.cio.gov/principles/)
 * [Cal-ITP - California Transit Data Guidelines](https://dot.ca.gov/cal-itp/california-minimum-general-transit-feed-specification-gtfs-guidelines)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -553,7 +553,7 @@ nav:
       - Fares v1: schedule/examples/fares-v1.md
       - Fares v2: schedule/examples/fares-v2.md
       - Frequencies: schedule/examples/frequencies.md
-      - Pathways: schedule/examples/pathways.md
+      - Pathways and accessibility: schedule/examples/pathways.md
       - Transfers: schedule/examples/transfers.md
       - Translations: schedule/examples/translations.md
       - Feed information: schedule/examples/feed-info.md
@@ -562,6 +562,7 @@ nav:
       - schedule/changes/index.md
       - Specification Amendment Process: schedule/process.md
     - Validate: schedule/validate.md
+    - Publish: schedule/publishing.md
   - GTFS Realtime: 
     - Getting Started: realtime/index.md
     - Reference: realtime/reference.md


### PR DESCRIPTION
Attempt to close #275. In this PR:
- Adding a "Publishing" section in the Index and as a button on the GTFS Schedule Landing page. 
