### PR TITLE
Add Fares v2 resources and intro video

### DIFF
--- a/docs/extensions/fares-v2.md
+++ b/docs/extensions/fares-v2.md
@@ -15,7 +15,7 @@ The main concepts that Fares v2 plans to represent are
 
 These concepts will allow data producers to model zone-based, time-dependent, and inter-agency fares. This extension project is being adopted in iterations. 
 
-You can see <a href="/schedule/examples/fares-v2" target="_blank">examples here</a> that show what can be modelled using the adopted Fares v2 base implementation.
+You can see <a href="/schedule/examples/fares-v2" target="_blank">examples here</a> that show what can be modelled using what has been officially adopted in GTFS.
 
 Producers may implement Fares v2 in the same dataset with Fares v1, since there is no technical conflict between the two. Consumers can choose which version to use independent of the other. With adoption and sufficient endorsement of Fares v2, Fares v1 may be deprecated in the future.
 

--- a/docs/schedule/examples/fares-v2.md
+++ b/docs/schedule/examples/fares-v2.md
@@ -12,7 +12,7 @@ In the interim, producers may implement Fares v2 alongside the implementation of
 
 The below examples outline how to model data using Fares v2 and it can be completed with experimental features outlined in the full [proposal document](https://share.mobilitydata.org/gtfs-fares-v2). 
 
-## Getting started with GTFS-Fares v2
+## GTFS-Fares v2 training and free resources
 
 To get started with GTFS Fares-v2, you can watch these four video tutorials and follow along with [this written resource](https://share.mobilitydata.org/Fares-v2-written-resource-guide-for-videos).
 - [Video 1](https://share.mobilitydata.org/faresv2-intro): GTFS Fares-v2: An introduction
@@ -21,6 +21,8 @@ To get started with GTFS Fares-v2, you can watch these four video tutorials and 
 - [Video 4](https://share.mobilitydata.org/faresv2-exporting-and-publishing): Exporting and Publishing GTFS Fares v2
 
 They have been created for transit agencies to understand the purpose of GTFS-Fares v2, as well as how to use Google Sheets to create, edit, and upload GTFS-Fares v2 data. 
+
+This [Fares v2 template](https://share.mobilitydata.org/faresv2-template) can be used for creating the necessary fares files from scratch.
 
 ## Define a transit fare
 

--- a/docs/schedule/examples/fares-v2.md
+++ b/docs/schedule/examples/fares-v2.md
@@ -6,7 +6,8 @@
 
 <hr>
 
-Fares v2 is a GTFS extension project that aims to address the limitations of Fares v1. This extension project is being adopted in GTFS in iterations and you can find more about the roadmap for its official adoption into GTFS and how to participate on [this page](/extensions/fares-v2/).
+Fares v2 is a GTFS extension project that aims to address the limitations of Fares v1. This extension project is being adopted in GTFS in iterations and you can find more about the roadmap for its official adoption into GTFS and how to participate on [the Fares v2 extension page](/extensions/fares-v2/).
+
 With the adoption and sufficient endorsement of Fares v2, Fares v1 may be deprecated in the future.
 In the interim, producers may implement Fares v2 alongside the implementation of Fares v1 in the same dataset as there exists no technical conflict between the two. Consumers will have the choice of which implementation to consume independently from the other. 
 

--- a/docs/schedule/examples/fares-v2.md
+++ b/docs/schedule/examples/fares-v2.md
@@ -13,7 +13,7 @@ In the interim, producers may implement Fares v2 alongside the implementation of
 
 The below examples outline how to model data using Fares v2 and it can be completed with experimental features outlined in the full [proposal document](https://share.mobilitydata.org/gtfs-fares-v2). 
 
-## GTFS-Fares v2 training and free resources
+## Fares v2 training and free resources
 
 To get started with GTFS Fares-v2, you can watch these four video tutorials and follow along with [this written resource](https://share.mobilitydata.org/Fares-v2-written-resource-guide-for-videos).
 - [Video 1](https://share.mobilitydata.org/faresv2-intro): GTFS Fares-v2: An introduction
@@ -25,7 +25,9 @@ They have been created for transit agencies to understand the purpose of GTFS-Fa
 
 This [Fares v2 template](https://share.mobilitydata.org/faresv2-template) can be used for creating the necessary fares files from scratch.
 
-## Define a transit fare
+## Fares v2 data modelling examples
+
+### Define a transit fare
 
 There are several ways to pay fares to use the Maryland Transit Administration system. <a href="https://www.mta.maryland.gov/regular-fares" target="_blank">There are four types of regular full price fare options:</a>
 
@@ -50,7 +52,7 @@ Transit tickets or fares are referred to as fare products in GTFS. They can be d
 
 <hr>
 
-## Create rules for single leg journeys
+### Create rules for single leg journeys
 
 In GTFS, a fare leg corresponds to a trip that a rider makes without transferring between different modes, routes, networks, or agencies. In the Maryland Transit Administration's feed, a single fare allows riders to travel within any pair of stops and subway stations within the `core` network of BaltimoreLink buses, Light RailLink and Metro SubwayLink routes.
 
@@ -69,7 +71,7 @@ Leg groups define trips within a network from an origin to a destination (or a s
 
 <hr>
 
-## Create rules for transfers
+### Create rules for transfers
 
 There is a 90 minute transfer for riders who purchase a one-way fare to ride BaltimoreLink local buses, Metro SubwayLink, or Light RailLink. This means that they can transfer an unlimited number of times between the local buses, subway, and light rail within the 90 minute timeframe.
 
@@ -97,7 +99,7 @@ After defining the fare, creating the appropriate `fare_leg_rule`, and defining 
 
 <sup>[Download the Maryland Transit Administration local bus GTFS feed](https://feeds.mta.maryland.gov/gtfs/local-bus)</sup>
 
-## Describe service locations in the same fare zone
+### Describe service locations in the same fare zone
 
 Some transit agencies operate a zone-based fare structure. Fare zones are divided geographic areas associated with different fare prices. In Bay Area’s BART system, fares are different depending on the origin and destination <a href="https://www.bart.gov/sites/default/files/docs/BART%20Clipper%20Fares%20Triangle%20Chart%20July%202022.pdf" target="_blank">(BART fare differences)</a>, and transit riders will need to know the right fare. Fare areas can be described using the [stops_areas.txt](../../reference/#stops_areastxt) file, which assigns stops from [stops.txt](../../reference/#stopstxt) to [areas.txt](../../reference/#areastxt).
 
@@ -150,7 +152,7 @@ The fare is identified in `fare_products.txt`.
 
 <hr>
 
-## Describe what fare media is accepted
+### Describe what fare media is accepted
 
 San Francisco Muni riders can use several different types of fare media to pay for their trip and validate their fare:
 
@@ -188,7 +190,7 @@ The <a href="https://www.mbta.com" target="_blank">Massachusetts Bay Transportat
 
 <sup><a href="https://www.mbta.com/developers/gtfs" target="_blank">See the Massachusetts Bay Transportation Authority feed</a></sup>
 
-## Define price differences based on fare media
+### Define price differences based on fare media
 
 Muni's fare price is different based on the fare media the rider uses. This example will cover how the adult local fare price changes when using cash or Clipper card. An adult local fare paid for with cash costs $3 USD and the same fare paid for with the Clipper card costs $2.50, 50 cents less.
 
@@ -220,7 +222,7 @@ In Apple Maps, riders can see how their fare price changes. You can compare fare
 <sup><a href="https://511.org/open-data/transit" target="_blank">See the San Francisco Bay Area Regional feed</a></sup>
 
 
-## Describe a contactless fare media option
+### Describe a contactless fare media option
 
 <a href="https://vimeo.com/539436401" target="_blank">The Clean Air Express in Northern Santa Barbara County accepts contactless payment</a> by credit card, Google Pay and Apple Pay.
 
@@ -242,7 +244,7 @@ The single ride fare product shown below has both `cash` and `tap-to-ride` fare 
 <sup><a href="https://gtfs.calitp.org/production/CleanAirExpressFaresv2.zip" target="_blank">Download the Clean Air Express feed</a></sup>
 
 
-## Define price differences based on time and day of trip
+### Define price differences based on time and day of trip
 
 Certain transit agencies vary their fares based on the time and/or day of the week. This means that fares are associated with a time period where the trip is made, such as peak, off-peak hours, or weekends. 
 
@@ -302,7 +304,7 @@ Note that `network_id` references the foreign ID `networks.network_id` or `route
 In this case, a user paying for a trip that departs at  7:30 AM would have to pay 5.00 USD (Peak fare) while another user departing at 11:30 AM would only have to pay a 3.00 USD fare (Off-peak fare).
 
 
-## Define time-variable fares along with zone based fares
+### Define time-variable fares along with zone based fares
 
 In New York's MTA Metro-North railroad network, fares vary based on both the time of the day of the trip, as well as the trip’s origin and destination areas. The following example illustrates the fare rules applicable to a trip from Grand Central Station to Cold Spring (NY, USA).
 

--- a/docs/schedule/examples/fares-v2.md
+++ b/docs/schedule/examples/fares-v2.md
@@ -6,10 +6,11 @@
 
 <hr>
 
-Fares v2 is a GTFS extension project that aims to address the limitations of Fares v1. This extension project is being adopted in iterations. The below examples outline how to model basic concepts, including fare products and how riders can use their fare for transfers. See more information about [the Fares v2 extension project here](/extensions/fares-v2/).
+Fares v2 is a GTFS extension project that aims to address the limitations of Fares v1. This extension project is being adopted in GTFS in iterations and you can find more about the roadmap for its official adoption into GTFS on [this page](/extensions/fares-v2/).
+With the adoption and sufficient endorsement of Fares v2, Fares v1 may be deprecated in the future.
+In the interim, producers may implement Fares v2 alongside the implementation of Fares v1 in the same dataset as there exists no technical conflict between the two. Consumers will have the choice of which implementation to consume independently from the other. 
 
-In the interim, producers may implement Fares v2 alongside implementation of Fares v1 in the same dataset as there exists no technical conflict between the two. Consumers will have the choice on which implementation to consume independently from the other. 
-With adoption and sufficient endorsement of Fares v2, Fares v1 may be deprecated in the future.
+The below examples outline how to model data using Fares v2 and it can be completed with experimental features outlined in the full [proposal document](https://share.mobilitydata.org/gtfs-fares-v2). 
 
 ## Define a transit fare
 

--- a/docs/schedule/examples/fares-v2.md
+++ b/docs/schedule/examples/fares-v2.md
@@ -6,11 +6,21 @@
 
 <hr>
 
-Fares v2 is a GTFS extension project that aims to address the limitations of Fares v1. This extension project is being adopted in GTFS in iterations and you can find more about the roadmap for its official adoption into GTFS on [this page](/extensions/fares-v2/).
+Fares v2 is a GTFS extension project that aims to address the limitations of Fares v1. This extension project is being adopted in GTFS in iterations and you can find more about the roadmap for its official adoption into GTFS and how to participate on [this page](/extensions/fares-v2/).
 With the adoption and sufficient endorsement of Fares v2, Fares v1 may be deprecated in the future.
 In the interim, producers may implement Fares v2 alongside the implementation of Fares v1 in the same dataset as there exists no technical conflict between the two. Consumers will have the choice of which implementation to consume independently from the other. 
 
 The below examples outline how to model data using Fares v2 and it can be completed with experimental features outlined in the full [proposal document](https://share.mobilitydata.org/gtfs-fares-v2). 
+
+## Getting started with GTFS-Fares v2
+
+To get started with GTFS Fares-v2, you can watch these four video tutorials and follow along with [this written resource](https://share.mobilitydata.org/Fares-v2-written-resource-guide-for-videos).
+- [Video 1](https://share.mobilitydata.org/faresv2-intro): GTFS Fares-v2: An introduction
+- [Video 2](https://share.mobilitydata.org/faresv2-setting-up-google-sheets): GTFS Fares v2: Setting up Google Sheets
+- [Video 3](https://share.mobilitydata.org/faresv2-creating-and-maintaining-data): GTFS Fares v2: Creating and Maintaining Data
+- [Video 4](https://share.mobilitydata.org/faresv2-exporting-and-publishing): Exporting and Publishing GTFS Fares v2
+
+They have been created for transit agencies to understand the purpose of GTFS-Fares v2, as well as how to use Google Sheets to create, edit, and upload GTFS-Fares v2 data. 
 
 ## Define a transit fare
 

--- a/docs/schedule/index.md
+++ b/docs/schedule/index.md
@@ -25,21 +25,24 @@ In order to create a GTFS feed follow the steps below.
 **Technical details about GTFS, what it is, and how to create and maintain data:**
 
 - [GTFS Introductory video](https://share.mobilitydata.org/GTFS-intro)
-- [GTFS Schedule Overview](https://gtfs.org/schedule/reference/)
+- [Data examples with various features](https://gtfs.org/schedule/examples/)
 - [World Bank "Intro to GTFS" online course](https://olc.worldbank.org/content/introduction-general-transit-feed-specification-gtfs-and-informal-transit-system-mapping)
 - [MBTA GTFS Onboarding](https://mybinder.org/v2/gh/mbta/gtfs_onboarding/main?urlpath=lab/tree/GTFS_Onboarding.ipynb)
 
-**View example feeds with various features:**
+**View example feeds:**
 
 - [GTFS Mobility Database](https://database.mobilitydata.org/) 
 - [Transitland](https://www.transit.land/)
-- [Data examples](https://gtfs.org/schedule/examples/)
+
+See more [data sources](../resources/data)
 
 **For free tools and instructional materials:**
 
 - [MobilityData GTFS Schedule Validator](https://gtfs-validator.mobilitydata.org/) 
-- [NRTAP lessons and GTFS Builder](https://www.nationalrtap.org/Technology-Tools/GTFS-Builder/Support)
+- [NRTAP GTFS Builder](https://www.nationalrtap.org/Technology-Tools/GTFS-Builder/Support)
 - [Arcadis IBI Data Tools](https://www.ibigroup.com/ibi-products/transit-data-tools/)
+
+See more [free tools](../resources/gtfs).
 
 **For ideas on vendors who offer GTFS services:**
 

--- a/docs/schedule/index.md
+++ b/docs/schedule/index.md
@@ -24,6 +24,7 @@ In order to create a GTFS feed follow the steps below.
 
 **Technical details about GTFS, what it is, and how to create and maintain data:**
 
+- [GTFS Introductory video](https://share.mobilitydata.org/GTFS-intro)
 - [GTFS Schedule Overview](https://gtfs.org/schedule/reference/)
 - [World Bank "Intro to GTFS" online course](https://olc.worldbank.org/content/introduction-general-transit-feed-specification-gtfs-and-informal-transit-system-mapping)
 - [MBTA GTFS Onboarding](https://mybinder.org/v2/gh/mbta/gtfs_onboarding/main?urlpath=lab/tree/GTFS_Onboarding.ipynb)

--- a/docs/schedule/index.md
+++ b/docs/schedule/index.md
@@ -34,7 +34,7 @@ In order to create a GTFS feed follow the steps below.
 - [GTFS Mobility Database](https://database.mobilitydata.org/) 
 - [Transitland](https://www.transit.land/)
 
-See more [data sources](../resources/data)
+See more [data sources](../resources/data).
 
 **For free tools and instructional materials:**
 


### PR DESCRIPTION
This PR adds the content drafted by Garnet Consulting for gtfs.org. More precisely:
- a link to the intro videos to GTFS and associated resources
- small fixes to some of the descriptions on the Fares v2 example page and the Fares v2 extension page
-  a link to the intro video
- small fixes to the GTFS Schedule home page