### PR TITLE
Amend realtime Best Practice to inform their addition to the spec

### DIFF
--- a/docs/realtime/best-practices.md
+++ b/docs/realtime/best-practices.md
@@ -147,7 +147,7 @@ The objectives of maintaining GTFS Realtime Best Practices are to:
 
 ### How to propose or amend published GTFS Realtime Best Practices
 
-GTFS applications and practices evolve, and so this document may need to be amended from time to time. To propose an amendment to this document, open a pull request [in the GTFS Realtime Best Practices GitHub repository](https://github.com/MobilityData/GTFS_Realtime_Best-Practices) and advocate for the change.
+The Best Practices are in the process of being merged into the spec. If you'd like to suggest a new best practice, please go to the [GTFS Reference GitHub repository](https://github.com/google/transit/) to open an issue or create a PR, or contact [specifications@mobilitydata.org](mailto:specifications@mobilitydata.org).
 
 ### Linking to This Document
 

--- a/docs/schedule/best-practices.md
+++ b/docs/schedule/best-practices.md
@@ -231,8 +231,8 @@ Working Group members voted on each Best Practice. Most Best Practices were appr
 
 ### Why not just change the GTFS reference?
 
-Good question! The process of examining the Specification, data usage and needs did indeed trigger some changes to the Specification (see [closed pull requests in GitHub](https://github.com/google/transit/pulls?q=is%3Apr+is%3Aclosed)). 
-Specification reference amendments are subject to a higher bar of scrutiny and comment than the Best Practices. Certain Best Practices are being merged into the spec based on their level of adoption and community consensus. Eventually, all GTFS Best Practices could become part of the core GTFS Reference.
+Good question! The process of examining the Specification, data usage and needs did indeed trigger some changes to the Specification. Since then, certain Best Practices have been merged into the spec based on their level of adoption and community consensus. 
+Eventually, the GTFS Best Practices will become part of the core GTFS Reference. To contribute to this effort, please go to the [GTFS Reference GitHub repository](https://github.com/google/transit/), or contact [specifications@mobilitydata.org](mailto:specifications@mobilitydata.org).
 
 ### How to check for conformance with these Best Practices?
 


### PR DESCRIPTION
In this PR: 
- adds a statement in the GTFS Realtime Best Practices with the intention to merge into the spec
- modifies a statement in the GTFS Schedule Best Practices to clarify the intention to merge into the spec