### PR TITLE
Fixed timing and duplication of automated PRs

### DIFF
--- a/.github/workflows/fetchdata.yml
+++ b/.github/workflows/fetchdata.yml
@@ -21,4 +21,4 @@ jobs:
           delete-branch: true
           labels: |
             automated-content-update
-          reviewers: isabelle-dr, emmambd
+          reviewers: tzujenchanmbd, Sergiodero

--- a/.github/workflows/fetchdata.yml
+++ b/.github/workflows/fetchdata.yml
@@ -8,15 +8,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4.0.0
+        uses: actions/checkout@v4.1.1
 
       - name: Run fetch data bash script
         run: bash ./scripts/fetchdata.sh
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v5.0.2
+        uses: peter-evans/create-pull-request@v6.0.0
         with:
           title: 'Automated content update'
           branch-suffix: timestamp
           delete-branch: true
+          labels: |
+            automated-content-update
           reviewers: isabelle-dr, emmambd

--- a/.github/workflows/remove-outdated-auto-content-update-prs.yml
+++ b/.github/workflows/remove-outdated-auto-content-update-prs.yml
@@ -1,0 +1,26 @@
+name: Remove outdated automatic content update PRs
+on:
+   schedule:
+        - cron: "50 23 * * *"
+
+jobs:
+    fetchdata:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Load secrets from 1Password
+              id: onepw_secrets
+              uses: 1Password/load-secrets-action@v1.3.1
+              with:
+                  export-env: true # Export loaded secrets as environment variables
+              env:
+                  OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+                  CREDENTIALS: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/ifkeehu5gzi7wy5ub5qvwkaire/credential"
+                
+            - name: Close stale issues
+              uses: actions/stale@v9.0.0
+              with:
+                  repo-token: ${{ env.CREDENTIALS }}
+                  only-labels: automated-content-update
+                  days-before-close: 1
+                  operations-per-run: 100
+                  close-pr-message: 'This PR has been closed to prevent the same PR from piling up if no one reviews it during the day. If need be a new PR will be created at midnight.'


### PR DESCRIPTION
This creates an action that 10 minutes before midnight UTC would close all PRs with a specific label, which I would add to the existing action. And delete the branch at the same time? This action doesn’t see PR titles, so I have to use a label.
Then at midnight the current action would run again, re-creating the PR if need be.