### PR TITLE
Add data sample to shapes

### DIFF
--- a/docs/documentation/schedule/components/shapes.md
+++ b/docs/documentation/schedule/components/shapes.md
@@ -10,3 +10,34 @@ When defining shapes, there is a balance between their level of detail (e.g. fol
 | **Fields associated** | shape_id<br>shape_pt_lat<br>shape_pt_lon<br>shape_pt_sequence<br>shape_dist_traveled | shape_id  | shape_dist_traveled |
 
 </div>
+
+### Sample data
+The following table shows a portion of a shape from the TriMet GTFS feed (download it [here](https://developer.trimet.org/GTFS.shtml)).
+
+[shapes.txt](/schedule/reference/#shapestxt)
+
+| shape_id | shape_pt_lat | shape_pt_lon | shape_pt_sequence | shape_dist_traveled |
+| --------- | ------------- | ------------- | ------------------ | ------------------- |
+| 558674     | 45.47623       | -122.721885    | 1                   | 0.0                  |
+| 558674     | 45.476235      | -122.72236     | 2                   | 121.9                |
+| 558674     | 45.476237      | -122.722523    | 3                   | 163.7                |
+| 558674     | 45.476242      | -122.723024    | 4                   | 292.2                |
+| 558674     | 45.476244      | -122.72316     | 5                    | 327.1               |
+
+[trips.txt](/schedule/reference/#tripstxt)
+
+|trip_id |route_id|direction_id|shape_id|
+|--------|--------|------------|--------|
+|13302375|1       |1           |558674  |
+|13302376|1       |1           |558674  |
+
+Because these two trips operate along the same route, in the same
+direction, starting and ending in the same location, they can be represented by the
+same shape.
+
+[stop_times.txt](/schedule/reference/#stop_timestxt)
+|trip_id |stop_sequence|shape_dist_traveled|
+|--------|-------------|-------------------|
+|13302375|1            |0                  |
+|13302375|2            |461.7              |
+|13302375|3            |1245               |

--- a/docs/documentation/schedule/components/shapes.md
+++ b/docs/documentation/schedule/components/shapes.md
@@ -26,14 +26,12 @@ The following table shows a portion of a shape from the TriMet GTFS feed (downlo
 
 [trips.txt](/schedule/reference/#tripstxt)
 
-|trip_id |route_id|direction_id|shape_id|
-|--------|--------|------------|--------|
-|13302375|1       |1           |558674  |
-|13302376|1       |1           |558674  |
-
-Because these two trips operate along the same route, in the same
-direction, starting and ending in the same location, they can be represented by the
-same shape.
+|trip_id |shape_id|
+|--------|--------|
+|13302373|558673  |
+|13302374|558673  |
+|13302375|558674  |
+|13302376|558674  |
 
 [stop_times.txt](/schedule/reference/#stop_timestxt)
 |trip_id |stop_sequence|shape_dist_traveled|


### PR DESCRIPTION
This PR is an experiment to go a step further with GTFS Components: adding a data sample. 

Note that the intention of GTFS Component is for users to get an understanding of what can be modeled with GTFS (not "how to model"), and we believe that a simple data sample helps with it. 
Other more detailed data examples and step-by-step instructions for modeling a feature can be included in other sections of gtfs.org

In the data sample, I've included all files and fields included in the feature, as well as any other fields that help understand the feature (such as primary keys but not only).
