### PR TITLE
feat: script to translate EN to many languages

### DIFF
--- a/scripts/simpleen-translator.sh
+++ b/scripts/simpleen-translator.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Array of target languages
+target_languages=("ES" "RU" "JA" "id" "DE" "PT-BR" "ko" "ZH" "zh-TW")
+
+escape_quotes() {
+    echo "$1" | sed 's/"/\\"/g'
+}
+
+# Argument provided to the script
+input_string="$1"
+
+# Loop through each target language
+for lang in "${target_languages[@]}"; do
+    # Replace placeholders with actual values
+    curl_command=$(cat <<EOF
+curl -s -X POST \
+   'https://api.simpleen.io/translate?auth_key=$SIMPLEEN_API_AUTH_KEY' \
+   -H 'Accept: application/json' \
+   -H 'Content-Type: application/json' \
+   -d '{
+      "dataformat": "Markdown",
+      "source_language": "EN",
+      "target_language": "$lang",
+      "glossary": 89,
+      "text": "$input_string"
+   }'
+EOF
+)
+    # Execute curl command
+    echo "Translating to $lang:"
+    eval $curl_command
+    echo ""
+done


### PR DESCRIPTION
Script that uses Simpleen to translate English to all 9 other languages required.

You need to export the `Simpleen API Auth Key` in terminal if you wish to use it locally, like this:
```shell
export SIMPLEEN_API_AUTH_KEY=VALUE
```
... where `VALUE` is the Auth Key.

Usage:
```shell
cd gtfs.org/
./scripts/simpleen-translator.sh "Hello my friend, how are you?"
```