### PR TITLE
set output deprecated

### DIFF
--- a/.github/workflows/upload_csv_glossaries_to_bucket_and_update_glossaries.yaml
+++ b/.github/workflows/upload_csv_glossaries_to_bucket_and_update_glossaries.yaml
@@ -77,7 +77,7 @@ jobs:
                     }, \
                     "inputConfig": { \
                       "gcsSource": { \
-                        "inputUri": "gs://${{ env.TARGET_BUCKET_URI }}/$file" \
+                        "inputUri": "gs://glossaries.mobilitydata.org/$file" \
                       } \
                     } \
                   }'

--- a/.github/workflows/upload_csv_glossaries_to_bucket_and_update_glossaries.yaml
+++ b/.github/workflows/upload_csv_glossaries_to_bucket_and_update_glossaries.yaml
@@ -51,7 +51,7 @@ jobs:
         id: authtoken
         run: |
           access_token=$(gcloud auth application-default print-access-token | sed '/^$/q')
-          echo "::set-output name=access_token::$access_token"
+          echo "{access_token}={$access_token}" >> $GITHUB_OUTPUT
 
       # Upload the file to GCP Bucket. They are uploaded at the root of the bucket, existing files will be replaced without confirmation.
       - name: Upload files

--- a/.github/workflows/upload_csv_glossaries_to_bucket_and_update_glossaries.yaml
+++ b/.github/workflows/upload_csv_glossaries_to_bucket_and_update_glossaries.yaml
@@ -41,10 +41,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2.1.0
         with:
           version: '>= 470.0.0'
-          service_account: ${{ env.GCLOUD_SERVICE_ACCOUNT }}
-          service_account_key: ${{ env.GCLOUD_SERVICE_ACCOUNT_JSON }}
           project_id: ${{ env.GCLOUD_PROJECT_ID }}
-          export_default_credentials: true
 
       # Get auth token, make sure to use only the first paragraph, sometimes other info is added and would cause issues
       - name: Get auth token


### PR DESCRIPTION
Fixed these three problems:
1. The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
2. setup-gcloud action, deprecated inputs: `Warning: Unexpected input(s) 'service_account', 'service_account_key', 'export_default_credentials', valid inputs are ['skip_install', 'version', 'project_id', 'install_components']`
3. Error when updating glossaries, added the full URI instead of env value, hoping it'll fix it:
```json
{
  "error": {
    "code": 400,
    "message": "Invalid JSON payload received. Expected an object key or }.\n\\\n          \"name\":\"\n^",
    "status": "INVALID_ARGUMENT"
  }
}
```