### PR TITLE
Fix Pathways example page navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -553,7 +553,7 @@ nav:
       - Fares v1: schedule/examples/fares-v1.md
       - Fares v2: schedule/examples/fares-v2.md
       - Frequencies: schedule/examples/frequencies.md
-      - Pathways and physical accessibility: schedule/examples/.md
+      - Pathways and physical accessibility: schedule/examples/pathways.md
       - Transfers: schedule/examples/transfers.md
       - Translations: schedule/examples/translations.md
       - Feed information: schedule/examples/feed-info.md


### PR DESCRIPTION
This change adds the pathways example page under the navigation list in the mkdocs.yml, this fixes a 404 error when trying to access the example page.

@eliasmbd can have a quick look? 