### PR TITLE
Update OneBusAway merge tool link

### DIFF
--- a/docs/en/resources/gtfs.md
+++ b/docs/en/resources/gtfs.md
@@ -109,7 +109,7 @@ Converters from various static schedule formats to and from GTFS.
 ## GTFS Merge Tools
 - [combine_gtfs_feeds](https://github.com/psrc/combine_gtfs_feeds) - A Python tool to combine multiple gtfs feeds into one feed/dataset.
 - [GTFS Kit](https://github.com/mrcagney/gtfs_kit) - A Python 3.8+ tool kit for analyzing and merging General Transit Feed Specification (GTFS) data. [Info on how to aggregate and clean feeds provided here](https://mrcagney.github.io/gtfs_kit_docs/index.html#module-gtfs_kit.cleaners).
-- [~~onebusaway-gtfs-merge-cli~~](http://developer.onebusaway.org/modules/onebusaway-gtfs-modules/1.3.94/onebusaway-gtfs-merge-cli.html) - A command line tool for merging GTFS feeds. Info provided at the link on how the tool detects and merges duplicate IDs.
+- [onebusaway-gtfs-merge-cli](https://github.com/OneBusAway/onebusaway-gtfs-modules/) - A command line tool for merging GTFS feeds. Info provided at the link on how the tool detects and merges duplicate IDs.
 - [Transitfeed merge function](https://github.com/google/transitfeed/wiki/Merge) - A Python library with a function to merge two different GTFS feeds.
 - [gtfsmerge](https://github.com/now8-org/gtfsmerge) - A Python Script to merge GTFS ZIP archives into one.
 


### PR DESCRIPTION
This PR updates the link for the OneBusAway merge tool in the Resources section. 

Note: The link was provided by Leonard Ehrenfried in the GTFS slack channel. Based on his comment, the merge tool will be relocated in the repo so for now the link directs to OBA main repo where they list all their tools. Once the tool is relocated we should update the link. Also pending: create PR in the AwesomeTransit repo to reflect this update there as well.

@eliasmbd do you mind taking a look and merging if it looks ok? Thanks!
