### PR TITLE
[Monthly update] February 2025

### DIFF
--- a/docs/en/documentation/schedule/change-history/revision-history.md
+++ b/docs/en/documentation/schedule/change-history/revision-history.md
@@ -2,6 +2,9 @@
 
 ### Revision History
 
+#### February 2025
+* Added rider_categories.txt. See [discussion](https://github.com/google/transit/pull/511).
+
 #### January 2025
 * Update agency_fare_url to expand its description and include fare information only. See [discussion](https://github.com/google/transit/pull/524).
 

--- a/docs/en/documentation/schedule/reference.md
+++ b/docs/en/documentation/schedule/reference.md
@@ -1,6 +1,6 @@
 ## General Transit Feed Specification Reference
 
-**Revised Jan 23, 2025. See [Revision History](../change-history/revision-history) for more details.**
+**Revised Feb 24, 2025. See [Revision History](../change-history/revision-history) for more details.**
 
 This document defines the format and structure of the files that comprise a GTFS dataset.
 
@@ -20,7 +20,8 @@ This document defines the format and structure of the files that comprise a GTFS
     -   [calendar_dates.txt](#calendar_datestxt)
     -   [fare_attributes.txt](#fare_attributestxt)
     -   [fare_rules.txt](#fare_rulestxt)
-    -   [timeframes.txt](#timeframestxt)    
+    -   [timeframes.txt](#timeframestxt) 
+    -   [rider\_categories.txt](#rider_categoriestxt)   
     -   [fare_media.txt](#fare_mediatxt)
     -   [fare_products.txt](#fare_productstxt) 
     -   [fare_leg_rules.txt](#fare_leg_rulestxt)
@@ -123,6 +124,7 @@ This specification defines the following files:
 |  [fare_attributes.txt](#fare_attributestxt)  | Optional | Fare information for a transit agency's routes. |
 |  [fare_rules.txt](#fare_rulestxt)  | Optional | Rules to apply fares for itineraries. |
 |  [timeframes.txt](#timeframestxt)  | Optional | Date and time periods to use in fare rules for fares that depend on date and time factors. |
+| [rider_categories.txt](#rider_categoriestxt) | Optional | Defines categories of riders (e.g. elderly, student). |
 |  [fare_media.txt](#fare_mediatxt)  | Optional | To describe the fare media that can be employed to use fare products. <br><br>File [fare_media.txt](#fare_mediatxt) describes concepts that are not represented in [fare_attributes.txt](#fare_attributestxt) and [fare_rules.txt](#fare_rulestxt). As such, the use of [fare_media.txt](#fare_mediatxt) is entirely separate from files [fare_attributes.txt](#fare_attributestxt) and [fare_rules.txt](#fare_rulestxt). |
 |  [fare_products.txt](#fare_productstxt)  | Optional | To describe the different types of tickets or fares that can be purchased by riders.<br><br>File [fare_products.txt](#fare_productstxt) describes fare products that are not represented in [fare_attributes.txt](#fare_attributestxt) and [fare_rules.txt](#fare_rulestxt). As such, the use of [fare_products.txt](#fare_productstxt) is entirely separate from files [fare_attributes.txt](#fare_attributestxt) and [fare_rules.txt](#fare_rulestxt). |
 |  [fare_leg_rules.txt](#fare_leg_rulestxt)  | Optional | Fare rules for individual legs of travel.<br><br>File [fare_leg_rules.txt](#fare_leg_rulestxt) provides a more detailed method for modeling fare structures. As such, the use of [fare_leg_rules.txt](#fare_leg_rulestxt) is entirely separate from files [fare_attributes.txt](#fare_attributestxt) and [fare_rules.txt](#fare_rulestxt). |
@@ -353,7 +355,7 @@ File: **Optional**
 Primary key (`fare_id`)
 
 **Versions**<br>
-There are two modelling options for describing fares. GTFS-Fares V1 is the legacy option for describing minimal fare information. GTFS-Fares V2 is an updated method that allows for a more detailed account of an agency's fare structure. Both are allowed to be present in a dataset, but only one method should be used by a data consumer for a given dataset. It is recommended that GTFS-Fares V2 takes precedence over GTFS-Fares V1. <br><br>The files associated with GTFS-Fares V1 are: <br>- [fare_attributes.txt](#fare_attributestxt)<br>- [fare_rules.txt](#fare_rulestxt)<br><br>The files associated with GTFS-Fares V2 are: <br>- [fare_media.txt](#fare_mediatxt)<br>- [fare_products.txt](#fare_productstxt)<br>- [fare_leg_rules.txt](#fare_leg_rulestxt)<br>- [fare_transfer_rules.txt](#fare_transfer_rulestxt)
+There are two modelling options for describing fares. GTFS-Fares V1 is the legacy option for describing minimal fare information. GTFS-Fares V2 is an updated method that allows for a more detailed account of an agency's fare structure. Both are allowed to be present in a dataset, but only one method should be used by a data consumer for a given dataset. It is recommended that GTFS-Fares V2 takes precedence over GTFS-Fares V1. <br><br>The files associated with GTFS-Fares V1 are: <br>- [fare_attributes.txt](#fare_attributestxt)<br>- [fare_rules.txt](#fare_rulestxt)<br><br>The files associated with GTFS-Fares V2 are: <br>- [fare_media.txt](#fare_mediatxt)<br>- [fare_products.txt](#fare_productstxt)<br>- [rider_categories.txt](#rider_categoriestxt)<br>- [fare_leg_rules.txt](#fare_leg_rulestxt)<br>- [fare_leg_join_rules.txt](#fare_leg_join_rulestxt)<br>- [fare_transfer_rules.txt](#fare_transfer_rulestxt)<br>- [timeframes.txt](#timeframestxt)<br>- [networks.txt](#networkstxt)<br>- [route_networks.txt](#route_networkstxt)<br>- [areas.txt](#areastxt)<br>- [stop_areas.txt](#stop_areastxt)
 
 <br>
 
@@ -410,6 +412,21 @@ There must not be overlapping time intervals for the same `timeframe_group_id` a
 - The “current day” is the current date of the fare event’s time, computed relative to the local timezone.  The “current day” may be different from the service day of a fare leg’s trip, especially for trips that extend past midnight.
 - The “time-of-day” for the fare event is computed relative to “current day” using GTFS Time field-type semantics.
 
+### rider_categories.txt
+
+File: **Optional** 
+
+Primary key (`rider_category_id`)
+
+Defines categories of riders (e.g. elderly, student).
+
+|  Field Name | Type | Presence | Description |
+|  ------ | ------ | ------ | ------ |
+|  `rider_category_id` | Unique ID | **Required** | Identifies a rider category. |
+|  `rider_category_name` | Text | **Required** | Rider category name as displayed to the rider. |
+|  `is_default_fare_category` | Enum | **Required** | Specifies if an entry in [rider_categories.txt](#rider_categoriestxt) should be considered the default category (i.e. the main category that should be displayed to riders). For example: Adult fare, Regular fare, etc. Valid options are:<br><br>`0` or empty - Category is not considered the default.<br>`1` - Category is considered the default one.<br><br>When multiple rider categories are eligible for a single fare product specified by a `fare_product_id`, there must be exactly one of these eligible rider categories indicated as the default rider category (`is_default_fare_category = 1`). |
+|  `eligibility_url` | URL | Optional | URL of a web page, usually from the operating agency, that provides detailed information about a specific rider category and/or describes its eligibility criteria. |
+
 ### fare_media.txt
 
 File: **Optional** 
@@ -428,14 +445,15 @@ To describe the different fare media that can be employed to use fare products. 
 
 File: **Optional**
 
-Primary key (`fare_product_id`, `fare_media_id`)
+Primary key (`fare_product_id`, `rider_category_id`, `fare_media_id`)
 
 Used to describe the range of fares available for purchase by riders or taken into account when computing the total fare for journeys with multiple legs, such as transfer costs.
 
 |  Field Name | Type | Presence | Description |
 |  ------ | ------ | ------ | ------ |
-| `fare_product_id` | ID | **Required** | Identifies a fare product or set of fare products.<br><br>Multiple records in [fare_products.txt](#fare_productstxt) may share the same `fare_product_id`, in which case all records with that ID will be retrieved when referenced from another file.<br><br>Multiple records may share the same `fare_product_id` but with different `fare_media_id`s, indicating various methods available for employing the fare product, potentially at different prices. |
+| `fare_product_id` | ID | **Required** | Identifies a fare product or set of fare products.<br><br>Multiple records sharing the same `fare_product_id` are permitted as long as they contain different `fare_media_id`s or `rider_category_id`s. Differing `fare_media_id`s would indicate various methods are available for employing the fare product, potentially at different prices. Differing `rider_category_id`s would indicate multiple rider categories are eligible for the fare product, potentially at different prices. |
 | `fare_product_name` | Text | Optional | The name of the fare product as displayed to riders. |
+| `rider_category_id` | Foreign ID referencing `rider_categories.rider_category_id` | Optional | Identifies a rider category eligible for the fare product.<br><br>If `fare_products.rider_category_id` is empty, the fare product is eligible for any `rider_category_id`.<br><br>When multiple rider categories are eligible for a single fare product specified by a `fare_product_id`, there must be only one of these rider categories indicated as the default rider category (`is_default_fare_category = 1`). |
 |  `fare_media_id` | Foreign ID referencing `fare_media.fare_media_id` | Optional |  Identifies a fare media that can be employed to use the fare product during the trip. When `fare_media_id` is empty, it is considered that the fare media is unknown.|
 | `amount` | Currency amount | **Required** | The cost of the fare product. May be negative to represent transfer discounts. May be zero to represent a fare product that is free. |
 | `currency` | Currency code | **Required** | The currency of the cost of the fare product. |

--- a/docs/es/documentation/schedule/change-history/revision-history.md
+++ b/docs/es/documentation/schedule/change-history/revision-history.md
@@ -2,6 +2,9 @@
 
 ### Historial de revisiones
 
+#### Febrero de 2025
+* Se agregó `rider_categories.txt`. Ver [discusión](https://github.com/google/transit/pull/511).
+
 #### Enero de 2025
 * Se actualizó agency_fare_url para ampliar su descripción e incluir solo información sobre tarifas. Ver [discusión](https://github.com/google/transit/pull/524).
 

--- a/docs/es/documentation/schedule/reference.md
+++ b/docs/es/documentation/schedule/reference.md
@@ -1,6 +1,6 @@
 ## Referencia de General Transit Feed Specification 
  
- **Revisado el 23 de enero de 2025. Consulte [Historial de revisiones](../change-history/revision-history) para obtener más detalles.** 
+ **Revisado el 24 de febrero de 2025. Consulte [Historial de revisiones](../change-history/revision-history) para obtener más detalles.** 
  
  Este documento define el formato y la estructura de los archivos que componen un conjunto de datos GTFS. 
  
@@ -15,12 +15,13 @@
     - [stops.txt](#stopstxt) 
     - [routes.txt](#routestxt) 
     - [trips.txt](#tripstxt) 
-    - [parada_times.txt](#stop_timestxt) 
+    - [stop_times.txt](#stop_timestxt) 
     - [calendar.txt](#calendartxt) 
     - [calendar_dates.txt](#calendar_datestxt) 
     - [fare_attributes.txt](#fare_attributestxt) 
     - [fare_rules.txt](#fare_rulestxt) 
     - [timeframes.txt](#timeframestxt) 
+    - [rider_categories.txt](#rider_categoriestxt) 
     - [fare_media.txt](#fare_mediatxt) 
     - [fare_products.txt](#fare_productstxt) 
     - [fare_leg_rules.txt](#fare_leg_rulestxt) 
@@ -122,6 +123,7 @@ La **clave principal** de un conjunto de datos es el campo o combinación de cam
  | [fare_attributes.txt](#fare_attributestxt) | Opcional | Información de tarifas para las rutas de una agencia de tránsito. | 
  | [fare_rules.txt](#fare_rulestxt) | Opcional | Reglas para aplicar tarifas por itinerarios. | 
  | [timeframes.txt](#timeframestxt) | Opcional | Períodos de fecha y hora que se utilizarán en las reglas de tarifas para tarifas que dependen de factores de date y hora. | 
+ | [rider_categories.txt](#rider_categoriestxt) | Opcional | Define categorías de pasajeros (por ejemplo, personas mayores, estudiantes). |
  | [fare_media.txt](#fare_mediatxt) | Opcional | Describir los medios tarifarios que se pueden emplear para utilizar productos tarifarios.<br><br> El archivo [fare_media.txt](#fare_mediatxt) describe conceptos que no están representados en [fare_attributes.txt](#fare_attributestxt) y [fare_rules.txt](#fare_rulestxt). Como tal, el uso de [fare_media.txt](#fare_mediatxt) es completamente independiente de los archivos [fare_attributes.txt](#fare_attributestxt) y [fare_rules.txt](#fare_rulestxt). | 
  | [fare_products.txt](#fare_productstxt) | Opcional | Describir los diferentes tipos de billetes o tarifas que pueden adquirir los pasajeros.<br><br> El archivo [fare_products.txt](#fare_productstxt) describe productos de tarifas que no están representados en [fare_attributes.txt](#fare_attributestxt) y [fare_rules.txt](#fare_rulestxt). Como tal, el uso de [fare_products.txt](#fare_productstxt) es completamente independiente de los archivos [fare_attributes.txt](#fare_attributestxt) y [fare_rules.txt](#fare_rulestxt). | 
  | [fare_leg_rules.txt](#fare_leg_rulestxt) | Opcional | Reglas de tarifas para tramos individuales de viaje.<br><br> El archivo [fare_leg_rules.txt](#fare_leg_rulestxt) proporciona un método más detallado para modelar estructuras de tarifas. Como tal, el uso de [fare_leg_rules.txt](#fare_leg_rulestxt) es completamente independiente de los archivos [fare_attributes.txt](#fare_attributestxt) y [fare_rules.txt](#fare_rulestxt). | 
@@ -352,8 +354,7 @@ La **clave principal** de un conjunto de datos es el campo o combinación de cam
  Clave principal (`fare_id`) 
  
  **Versiones**<br> 
- Hay dos opciones de modelado para describir tarifas. GTFS- Tarifas V1 es la opción heredada para describir información mínima de tarifas. GTFS-Fares V2 es un método actualizado que permite una descripción más detallada de la estructura de tarifas de una agencia. Se permite que ambos estén presentes en un conjunto de datos, pero un consumidor de datos solo debe utilizar un método para un conjunto de datos determinado. Se recomienda que GTFS-Fares V2 tenga prioridad sobre GTFS- Tarifas V1.<br><br> Los archivos asociados con GTFS- Tarifas V1 son:<br> - [fare_attributes.txt](#fare_attributestxt)<br> - [fare_rules.txt](#fare_rulestxt)<br><br> Los archivos asociados con GTFS-Fares V2 son:<br> - [fare_media.txt](#fare_mediatxt)<br> - [fare_products.txt](#fare_productstxt)<br> - [fare_leg_rules.txt](#fare_leg_rulestxt)<br> - [fare_transfer_rules.txt](#fare_transfer_rulestxt) 
- 
+ Hay dos opciones de modelado para describir tarifas. GTFS- Tarifas V1 es la opción heredada para describir información mínima de tarifas. GTFS-Fares V2 es un método actualizado que permite una descripción más detallada de la estructura de tarifas de una agencia. Se permite que ambos estén presentes en un conjunto de datos, pero un consumidor de datos solo debe utilizar un método para un conjunto de datos determinado. Se recomienda que GTFS-Fares V2 tenga prioridad sobre GTFS- Tarifas V1.<br><br> Los archivos asociados con GTFS-Fares V1 son: <br> - [fare_attributes.txt](#fare_attributestxt) <br> - [fare_rules.txt](#fare_rulestxt) <br><br> Los archivos asociados con GTFS-Fares V2 son:<br> - [fare_media.txt](#fare_mediatxt) <br> - [fare_products.txt](#fare_productstxt) <br> - [rider_categories.txt](#rider_categoriestxt) <br> - [fare_leg_rules.txt](#fare_leg_rulestxt)<br> - [fare_leg_join_rules.txt](#fare_leg_join_rulestxt)<br> - [fare_transfer_rules.txt](#fare_transfer_rulestxt)<br> - [timeframes.txt](#timeframestxt)<br> - [networks.txt](#networkstxt)<br> - [route_networks.txt](#route_networkstxt)<br> - [areas.txt](#areastxt)<br> - [stop_areas.txt](#stop_areastxt)
 <br> 
 
  | Nombre del campo | Tipo | Presencia | Descripción | 
@@ -408,6 +409,21 @@ La **clave principal** de un conjunto de datos es el campo o combinación de cam
 - Al evaluar el tiempo de un evento de tarifa con [timeframes.txt](#timeframestxt), el tiempo del evento se calcula en la hora local utilizando la zona horaria local, según lo determinado por `stop_timezone`, si se especifica, de la parada o estación principal para el evento de tarifa. Si no se especifica, se debe utilizar la zona horaria de la agencia del feed. 
  - El “día actual” es la date actual del evento de tarifa, calculada en relación con la zona horaria local. El “día actual” puede ser diferente del día de servicio de un viaje de tarifa, especialmente para viajes que se extienden después de la medianoche. 
  - La “hora del día” para el evento de tarifa se calcula en relación con el “día actual” utilizando la semántica del tipo de campo Tiempo GTFS. 
+
+### rider_categories.txt 
+
+Archivo: **Opcional**
+
+Clave principal (`rider_category_id`)
+
+Define categorías de pasajeros (por ejemplo, personas mayores, estudiantes).
+
+| Nombre del campo | Tipo | Presencia | Descripción |
+|------|------|------|------|
+| `rider_category_id` | ID única |**Obligatorio**| Identifica una categoría de pasajero. |
+| `rider_category_name` | Text |**Obligatorio**| Nombre de la categoría del pasajero tal como se muestra al pasajero. |
+| `is_default_fare_category` | Enumeración |**Obligatorio**| Especifica si una entrada en [rider_categories.txt](#rider_categoriestxt) debe considerarse la categoría predeterminada (es decir, la categoría principal que debe mostrarse a los pasajeros). Por ejemplo: Tarifa de adulto, Tarifa regular, etc. Las opciones válidas son:<br><br> `0` o vacío: la categoría no se considera predeterminada.<br> `1` - La categoría se considera la predeterminada.<br><br> Cuando varias categorías de pasajeros son elegibles para un único producto tarifario especificado por un `fare_product_id`, debe haber exactamente una de estas categorías de pasajeros elegibles indicada como la categoría de pasajero predeterminada (`is_default_fare_category = 1`). |
+| `eligibility_url` | URL | Opcional | URL de una página web, generalmente de la agencia operadora, que proporciona información detallada sobre una categoría de pasajero específica y/o describe sus criterios de elegibilidad. |
  
 ### fare_media.txt 
  
@@ -427,14 +443,15 @@ La **clave principal** de un conjunto de datos es el campo o combinación de cam
  
  Archivo: **Opcional** 
  
- Clave principal (`fare_product_id`, `fare_media_id`) 
+ Clave principal (`fare_product_id`, `rider_category_id`, `fare_media_id`) 
  
  Se utiliza para describir el rango de tarifas disponibles para la compra por los pasajeros o se tienen en cuenta al calcular la tarifa total para viajes con múltiples tramos, como los costos de transferencia. 
 
  | Nombre del campo | Tipo | Presencia | Descripción | 
  |------|------|------|------| 
- | `fare_product_id` | ID | **Obligatorio** | Identifica un producto tarifario o un conjunto de productos tarifarios.<br><br> Varios registros en [fare_products.txt](#fare_productstxt) pueden compartir el mismo `fare_product_id`, en cuyo caso todos los registros con esa ID se recuperarán cuando se haga referencia a ellos desde otro archivo.<br><br> Varios registros pueden compartir el mismo `fare_product_id` pero con diferentes `fare_media_id`, lo que indica varios métodos disponibles para emplear el producto de tarifa, potencialmente a diferentes precios. | 
+ | `fare_product_id` | ID | **Obligatorio** | Identifica un producto tarifario o un conjunto de productos tarifarios.<br><br> Se permiten varios registros que compartan el mismo `fare_product_id` siempre y cuando contengan diferentes `fare_media_id` o `rider_category_id`. Los `fare_media_id` diferentes indicarían que hay varios métodos disponibles para emplear el producto tarifario, potencialmente a diferentes precios. Los `rider_category_id` diferentes indicarían que varias categorías de pasajeros son elegibles para el producto tarifario, potencialmente a diferentes precios. |
  | `fare_product_name` | Text | Opcional | El nombre del producto de tarifa que se muestra a los pasajeros. | 
+ | `rider_category_id` | Identificación externa que hace referencia a `rider_categories.rider_category_id` | Opcional | Identifica una categoría de pasajero elegible para el producto tarifario.<br><br> Si `fare_products.rider_category_id` está vacío, el producto de tarifa es elegible para cualquier `rider_category_id`.<br><br> Cuando varias categorías de pasajeros son elegibles para un único producto de tarifa especificado por un `fare_product_id`, debe haber solo una de estas categorías de pasajeros indicada como la categoría de pasajero predeterminada (`is_default_fare_category = 1`). |
  | `fare_media_id` | ID extranjera que hace referencia a `fare_media.fare_media_id` | Opcional | Identifica un medio tarifario que se puede emplear para utilizar el producto tarifario durante el viaje. Cuando `fare_media_id` está vacío, se considera que el medio de tarifa es desconocido.| 
  | `amount` | Cantidad de moneda | **Obligatorio** | El costo del producto tarifario. Puede ser negativo para representar descuentos en transferencias. Puede ser cero para representar un producto tarifario gratuito. | 
  | `currency` | Código de moneda | **Obligatorio** | La moneda del costo del producto tarifario. | 

--- a/docs/fr/documentation/schedule/change-history/revision-history.md
+++ b/docs/fr/documentation/schedule/change-history/revision-history.md
@@ -2,6 +2,9 @@
 
 ### Historique des révisions
 
+#### Février 2025
+* Ajout de `rider_categories.txt`. Voir [discussion](https://github.com/google/transit/pull/511).
+
 #### Janvier 2025
 * Mettre à jour agency_fare_url pour étendre sa description et inclure les informations sur les tarifs. Voir [discussion](https://github.com/google/transit/pull/524).
 

--- a/docs/fr/documentation/schedule/reference.md
+++ b/docs/fr/documentation/schedule/reference.md
@@ -1,6 +1,6 @@
 ## Référence de General Transit Feed Specification 
  
- **Révisé le 23 janvier 2025. Voir [Historique des révisions](../change-history/revision-history) pour plus de détails.** 
+ **Révisé le 24 février 2025. Voir [Historique des révisions](../change-history/revision-history) pour plus de détails.** 
  
  Ce document définit le format et la structure de les fichiers qui composent un jeu de données GTFS. 
  
@@ -21,6 +21,7 @@
       - [fare_attributes.txt](#fare_attributestxt) 
       - [fare_rules.txt](#fare_rulestxt) 
       - [timeframes.txt](#timeframestxt) 
+      - [rider_categories.txt](#rider_categoriestxt)
       - [fare_media.txt](#fare_mediatxt) 
       - [fare_products.txt](#fare_productstxt) 
       - [tarif _leg_rules.txt](#fare_leg_rulestxt) 
@@ -123,6 +124,7 @@
  | [fare_attributes.txt](#fare_attributestxt) | Optionnel | Informations tarifaires pour les itinéraires d’une agence de transport en commun. | 
  | [fare_rules.txt](#fare_rulestxt) | Optionnel | Règles d’application des tarifs pour les itinéraires. | 
  | [timeframes.txt](#timeframestxt) | Optionnel | Périodes de date et d’heure à utiliser dans les règles tarifaires pour les tarifs qui dépendent de facteurs de date et d’heure. | 
+ | [rider_categories.txt](#rider_categoriestxt) | Optionnel | Définit les catégories de passagers (par exemple, personnes âgées, étudiants). |
  | [fare_media.txt](#fare_mediatxt) | Optionnel | Décrire les supports tarifaires qui peuvent être utilisés pour utiliser les produits tarifaires.<br><br> Le fichier [fare_media.txt](#fare_mediatxt) décrit les concepts qui ne sont pas représentés dans [fare_attributes.txt](#fare_attributestxt) et [fare_rules.txt](#fare_rulestxt). En tant que tel, l’utilisation de [fare_media.txt](#fare_mediatxt) est entièrement distincte des fichiers [fare_attributes.txt](#fare_attributestxt) et [fare_rules.txt](#fare_rulestxt). | 
  | [fare_products.txt](#fare_productstxt) | Optionnel | Décrire les différents types de billets ou de tarifs pouvant être achetés par les passagers.<br><br> Le fichier [fare_products.txt](#fare_productstxt) décrit les produits tarifaires qui ne sont pas représentés dans [fare_attributes.txt](#fare_attributestxt) et [fare_rules.txt](#fare_rulestxt). En tant que tel, l’utilisation de [fare_products.txt](#fare_productstxt) est entièrement distincte des fichiers [fare_attributes.txt](#fare_attributestxt) et [fare_rules.txt](#fare_rulestxt). | 
  | [fare_leg_rules.txt](#fare_leg_rulestxt) | Optionnel | Règles tarifaires pour les différents tronçons du voyage.<br><br> Le fichier [fare_leg_rules.txt](#fare_leg_rulestxt) fournit une méthode plus détaillée pour modéliser les structures tarifaires. En tant que tel, l’utilisation de [fare_leg_rules.txt](#fare_leg_rulestxt) est entièrement distincte des fichiers [fare_attributes.txt](#fare_attributestxt) et [fare_rules.txt](#fare_rulestxt). | 
@@ -353,7 +355,7 @@
  Clé primaire (`fare_id`) 
  
  **Versions**<br> 
- Il existe deux options de modélisation pour décrire les tarifs. GTFS-Fares v1 est l’option héritée pour décrire les informations tarifaires minimales. GTFS-Fares V2 est une méthode mise à jour qui permet un compte rendu plus détaillé de la structure tarifaire d’une agence. Les deux peuvent être présentes dans un jeu de données, mais une seule méthode doit être utilisée par un application réutilisatrice de données pour un jeu de données donné. Il est recommandé que GTFS-Fares V2 soit prioritaire sur GTFS-Fares v1.<br><br> Les fichiers associés à GTFS-Fares v1 sont :<br> - [fare_attributes.txt](#fare_attributestxt)<br> - [fare_rules.txt](#fare_rulestxt)<br><br> Les fichiers associés à GTFS-Fares V2 sont :<br> - [fare_media.txt](#fare_mediatxt)<br> - [fare_products.txt](#fare_productstxt)<br> - [fare_leg_rules.txt](#fare_leg_rulestxt)<br> - [fare_transfer_rules.txt](#fare_transfer_rulestxt) 
+ Il existe deux options de modélisation pour décrire les tarifs. GTFS-Fares v1 est l’option héritée pour décrire les informations tarifaires minimales. GTFS-Fares V2 est une méthode mise à jour qui permet un compte rendu plus détaillé de la structure tarifaire d’une agence. Les deux peuvent être présentes dans un jeu de données, mais une seule méthode doit être utilisée par un application réutilisatrice de données pour un jeu de données donné. Il est recommandé que GTFS-Fares V2 soit prioritaire sur GTFS-Fares v1.<br><br> Les fichiers associés à GTFS-Fares v1 sont :<br>- [fare_attributes.txt](#fare_attributestxt)<br>- [fare_rules.txt](#fare_rulestxt)<br><br> Les fichiers associés à GTFS-Fares V2 sont :<br>- [fare_media.txt](#fare_mediatxt)<br>- [fare_products.txt](#fare_productstxt)<br>- [rider_categories.txt](#rider_categoriestxt)<br>- [fare_leg_rules.txt](#fare_leg_rulestxt)<br>- [fare_leg_join_rules.txt](#fare_leg_join_rulestxt)<br>- [fare_transfer_rules.txt](#fare_transfer_rulestxt)<br>- [timeframes.txt](#timeframestxt)<br>- [networks.txt](#networkstxt)<br>- [route_networks.txt](#route_networkstxt)<br>- [areas.txt](#areastxt)<br>- [stop_areas.txt](#stop_areastxt)
  
 <br> 
  
@@ -409,7 +411,22 @@
 - Lors de l’évaluation de l’heure d’un événement tarifaire par rapport à [timeframes.txt](#timeframestxt), l’heure de l’événement est calculée en heure locale en utilisant le fuseau horaire local, tel que déterminé par le `stop_timezone`, si spécifié, de l’arrêt ou de la gare parent pour l’événement tarifaire. S’il n’est pas spécifié, le fuseau horaire de l’agence du flux doit être utilisé à la place. 
  - Le « jour en cours » est la date actuelle de l’événement tarifaire, calculée par rapport au fuseau horaire local. Le « jour en cours » peut être différent du jour de service d’un trajet tarifaire, en particulier pour les trajets qui s’étendent après minuit. 
  - L’« heure de la journée » pour l’événement tarifaire est calculée par rapport au « jour en cours » à l’aide de la sémantique de type champ GTFS Time. 
- 
+
+### rider_categories.txt
+
+Fichier : **Optionnel**
+
+Clé primaire (`rider_category_id`)
+
+Définit les catégories de passagers (par exemple, personnes âgées, étudiants).
+
+| Nom du champ | Type | Présence | Description |
+|------|------|------|------|
+| `rider_category_id` | ID unique | **Requis** | Identifie une catégorie de passager. |
+| `rider_category_name` | Text | **Requis** | Nom de la catégorie de passager tel qu’il est affiché au passager. |
+| `is_default_fare_category` | Enum | **Requis** | Spécifie si une entrée dans [rider_categories.txt](#rider_categoriestxt) doit être considérée comme la catégorie par défaut (c’est-à-dire la catégorie principale qui doit être affichée aux passagers). Par exemple : tarif adulte, tarif normal, etc. Les options valides sont :<br><br> `0` ou vide - La catégorie n’est pas considérée comme la valeur par défaut.<br> `1` - La catégorie est considérée comme celle par défaut.<br><br> Lorsque plusieurs catégories de passagers sont admissibles à un produit tarifaire unique spécifié par un `fare_product_id`, il doit y avoir exactement une de ces catégories de passagers admissibles indiquée comme catégorie de passager par défaut (`is_default_fare_category = 1`). |
+| `eligibility_url` | URL | Optionnel | URL d’une page Web, généralement de l’agence exploitante, qui fournit des informations détaillées sur une catégorie de passager spécifique et/ou décrit ses critères d’éligibilité. |
+
 ### fare_media.txt 
  
  Fichier : **Optionnel** 
@@ -428,14 +445,15 @@
  
  Fichier : **Optionnel** 
  
- Clé primaire (`fare_product_id`, `fare_media_id`) 
+ Clé primaire (`fare_product_id`, `rider_category_id`, `fare_media_id`) 
  
  Utilisée pour décrire la gamme de tarifs disponibles à l’achat par les passagers ou pris en compte dans le calcul du tarif total pour les trajets à plusieurs tronçons, comme les frais de transfert. 
  
  | Nom du champ | Tapez | Présence | Descriptif | 
  |------|------|------|------| 
- | `fare_product_id` | ID | **Requis** | Identifie un produit tarifaire ou un ensemble de produits tarifaires.<br><br> Plusieurs entrées dans [fare_products.txt](#fare_productstxt) peuvent partager le même `fare_product_id`, auquel cas toutes les entrées avec cet ID seront récupérées lorsqu’elles seront référencées à partir d’un autre fichier.<br><br> Plusieurs entrées peuvent partager le même `fare_product_id` mais avec des `fare_media_id` différents, indiquant diverses méthodes disponibles pour utiliser le produit tarifaire, potentiellement à des prix différents. | 
+ | `fare_product_id` | ID | **Requis** | Identifie un produit tarifaire ou un ensemble de produits tarifaires.<br><br> Plusieurs enregistrements partageant le même `fare_product_id` sont autorisés à condition qu’ils contiennent des `fare_media_id` ou `rider_category_id` différents. Des `fare_media_id` différents indiqueraient que diverses méthodes sont disponibles pour utiliser le produit tarifaire, potentiellement à des prix différents. Des `rider_category_id` différents indiqueraient que plusieurs catégories de passagers sont éligibles pour le produit tarifaire, potentiellement à des prix différents. |
  | `fare_product_name` | Texte | Optionnel | Le nom du produit tarifaire tel qu’affiché aux passagers. | 
+ | `rider_category_id` | ID étranger référençant `rider_categories.rider_category_id` | Optionnel | Identifie une catégorie de passager éligible pour le produit tarifaire.<br><br> Si `fare_products.rider_category_id` est vide, le produit tarifaire est éligible pour n’importe quel `rider_category_id`.<br><br> Lorsque plusieurs catégories de passagers sont éligibles à un produit tarifaire unique spécifié par un `fare_product_id`, une seule de ces catégories de passagers doit être indiquée comme catégorie de passager par défaut (`is_default_fare_category = 1`).
  | `fare_media_id` | ID étranger faisant référence à `fare_media.fare_media_id` | Optionnel | Identifie un support tarifaire qui peut être utilisé pour utiliser le produit tarifaire pendant le voyage. Lorsque `fare_media_id` est vide, on considère que le support tarifaire est inconnu.| 
  | `amount` | Montant en devise | **Requis** | Le coût du produit tarifaire. Peut être négatif pour représenter les remises de transfert. Peut être zéro pour représenter un produit tarifaire gratuit. | 
  | `currency` | Code devise | **Requis** | La devise du coût du produit tarifaire. | 

--- a/docs/ja/documentation/schedule/change-history/revision-history.md
+++ b/docs/ja/documentation/schedule/change-history/revision-history.md
@@ -2,10 +2,14 @@
 
 ### 改訂履歴
 
-#### 2025 年 1 月
+#### 2025年2月
+
+* rider_categories.txtを追加しました。[ディスカッション](https://github.com/google/transit/pull/511) を参照してください。
+
+#### 2025年1月
 * agency_fare_url を更新して説明を拡張し、運賃情報のみを含めます。[ディスカッション](https://github.com/google/transit/pull/524) を参照してください。
 
-#### 2024 年 12 月
+#### 2024年12月
 * `fare_leg_join_rules.txt` を追加し、実効運賃区間の概念を導入しました。[ディスカッション](https://github.com/google/transit/pull/439) を参照してください。
 
 #### 2024年9月

--- a/docs/ja/documentation/schedule/reference.md
+++ b/docs/ja/documentation/schedule/reference.md
@@ -5,7 +5,7 @@ description: GTFS scheduleの詳細を確認し、リファレンス ドキュ�
 
 ##General Transit Feed Specificationリファレンス
 
-**2025 年 1 月 23 日に改訂されました。詳細については、[改訂履歴](../change-history/revision-history) を参照してください。**
+**2025 年 2 月 24 日に改訂されました。詳細については、[改訂履歴](../change-history/revision-history) を参照してください。**
 
 このドキュメントでは、GTFS データセットを構成するファイルの形式と構造を定義します。
 
@@ -25,7 +25,8 @@ description: GTFS scheduleの詳細を確認し、リファレンス ドキュ�
     -   [calendar_dates.txt](#calendar_datestxt)
     -   [fare_attributes.txt](#fare_attributestxt)
     -   [fare_rules.txt](#fare_rulestxt)
-    -   [timeframes.txt](#timeframestxt)    
+    -   [timeframes.txt](#timeframestxt)
+    -   [rider_categories.txt](#rider_categoriestxt)    
     -   [fare_media.txt](#fare_mediatxt)
     -   [fare_products.txt](#fare_productstxt) 
     -   [fare_leg_rules.txt](#fare_leg_rulestxt)
@@ -127,6 +128,7 @@ _例: `trip_id` フィールドと `stop_sequence` フィールドは、[stop_ti
 | [fare_attributes.txt](#fare_attributestxt) |任意| 交通事業者のルート・路線系統の運賃情報。 |
 | [fare_rules.txt](#fare_rulestxt) |任意| 旅程に運賃を適用するルール。 |
 | [timeframes.txt](#timeframestxt) |任意|dateと時間の要素に依存する運賃の運賃ルールで使用するdateと時間の期間。 |
+| [rider_categories.txt](#rider_categoriestxt) |任意| 乗客のカテゴリを定義します (例: 高齢者、学生)。 |
 | [fare_media.txt](#fare_mediatxt) |任意|チケット商品を使用するために使用できる運賃メディアを説明します。<br><br>ファイル [fare_media.txt](#fare_mediatxt) は、[fare_attributes.txt](#fare_attributestxt) および [fare_rules.txt](#fare_rulestxt) に示されていない概念を説明しています。そのため、[fare_media.txt](#fare_mediatxt) の使用は、ファイル [fare_attributes.txt](#fare_attributestxt) および [fare_rules.txt](#fare_rulestxt) とは完全に独立しています。|
 | [fare_products.txt](#fare_productstxt) |任意| 乗客が購入できるさまざまな種類のチケットまたは運賃を説明しています。<br><br>ファイル [fare_products.txt](#fare_productstxt) には、[fare_attributes.txt](#fare_attributestxt) および [fare_rules.txt](#fare_rulestxt) に示されていないチケット商品が記載されています。そのため、[fare_products.txt](#fare_productstxt) の使用は、ファイル [fare_attributes.txt](#fare_attributestxt) および [fare_rules.txt](#fare_rulestxt) とは完全に独立しています。|
 | [fare_leg_rules.txt](#fare_leg_rulestxt) |任意| 個々の旅行区間の運賃規則。<br><br>ファイル [fare_leg_rules.txt](#fare_leg_rulestxt) は、運賃構造をモデル化するためのより詳細な方法を提供します。そのため、[fare_leg_rules.txt](#fare_leg_rulestxt) の使用は、ファイル [fare_attributes.txt](#fare_attributestxt) および [fare_rules.txt](#fare_rulestxt) とは完全に別です。 |
@@ -356,7 +358,7 @@ _例: `trip_id` フィールドと `stop_sequence` フィールドは、[stop_ti
 主キー(`fare_id`)
 
 **バージョン**<br>
-運賃を記述するためのモデリング 任意は 2 つあります。GTFS-Fares V1 は、最小限の運賃情報を記述するための従来の任意です。GTFS-Fares V2 は、交通事業者の運賃構造をより詳細に説明できる更新された方法です。データセットには両方の方法を使用できますが、特定のデータセットに対してデータ コンシューマーが使用できる方法は 1 つだけです。GTFS-Fares V2 を GTFS-Fares V1 よりも優先することをお勧めします。 <br><br>GTFS-Fares V1 に関連付けられているファイルは次のとおりです: <br>- [fare_attributes.txt](#fare_attributestxt)<br>- [fare_rules.txt](#fare_rulestxt)<br><br>GTFS-Fares V2 に関連付けられているファイルは次のとおりです: <br>- [fare_media.txt](#fare_mediatxt)<br>- [fare_products.txt](#fare_productstxt)<br>- [fare_leg_rules.txt](#fare_leg_rulestxt)<br>- [fare_transfer_rules.txt](#fare_transfer_rulestxt)
+運賃を記述するためのモデリング 任意は 2 つあります。GTFS-Fares V1 は、最小限の運賃情報を記述するための従来の任意です。GTFS-Fares V2 は、交通事業者の運賃構造をより詳細に説明できる更新された方法です。データセットには両方の方法を使用できますが、特定のデータセットに対してデータ コンシューマーが使用できる方法は 1 つだけです。GTFS-Fares V2 を GTFS-Fares V1 よりも優先することをお勧めします。 <br><br> GTFS- Fares v1に関連付けられているファイルは次のとおりです。<br> - [fare_attributes.txt](#運賃属性txt)<br> - [fare_rules.txt](#運賃規則txt)<br><br> GTFS-Fares v2に関連付けられているファイルは次のとおりです。<br> - [fare_media.txt](#fare_mediatxt)<br> - [fare_products.txt](#fare_productstxt)<br> - [rider_categories.txt](#rider_categoriestxt)<br> - [fare_leg_rules.txt](#運賃規則txt)<br> - [fare_leg_join_rules.txt](#fare_leg_join_rulestxt)<br> - [fare_transfer_rules.txt](#運賃振替ルールtxt)<br> - [timeframes.txt](#timeframestxt)<br> - [networks.txt](#networkstxt)<br> - [route_networks.txt](#route_networkstxt)<br> - [areas.txt](#areastxt)<br> - [stop_areas.txt](#stop_areastxt)
 
 <br> 
 
@@ -413,6 +415,21 @@ _例: `trip_id` フィールドと `stop_sequence` フィールドは、[stop_ti
 - `現在の日`は、ローカル タイムゾーンを基準に計算された運賃イベントの時間の現在のdateです。`現在の日`は、特に深夜を過ぎる便の場合、運賃区間の便のサービス日とは異なるしてもよい。
 - 運賃イベントの`時刻`は、GTFS 時間フィールドタイプのセマンティクスを使用して、`現在の日`を基準にして計算されます。
 
+### rider_categories.txt 
+
+ファイル: **任意**
+
+主キー(`rider_category_id`)
+
+ライダーのカテゴリを定義します (例: 高齢者、学生)。
+
+| フィールド名 | タイプ | 存在 | 説明 |
+|------|------|------|------|
+| `rider_category_id` |ユニーク ID |**必須**| ライダー カテゴリを識別します。 |
+| `rider_category_name` |Text|**必須**|乗客に表示される乗客カテゴリ名。 |
+| `is_default_fare_category` | 列挙型 |**必須**| [rider_categories.txt](#rider_categoriestxt) のエントリをデフォルト カテゴリ (つまり、乗客に表示さするべきであるメイン カテゴリ) と見なすするべきであるどうかを指定します。例: 大人料金、通常料金など。有効なオプションは次のとおりです。<br><br> `0` または空 - カテゴリはデフォルトとは見なされません。<br> `1` - カテゴリはデフォルトのものと見なされます。<br><br> `fare_product_id`で指定された単一の運賃商品に複数の乗客カテゴリが適格である場合、これらの適格な乗客カテゴリのうち 1 つだけがデフォルトの乗客カテゴリ (`is_default_fare_category = 1`) として指定されてしなければならない必要があります。 |
+| `eligibility_url` | URL |任意| 通常は運行事業者が提供する、特定の乗客カテゴリに関する詳細情報を提供したり、その適格基準を説明したりする Web ページの URL。 |
+
 ### fare_media.txt 
 
 ファイル: **任意**
@@ -431,14 +448,15 @@ _例: `trip_id` フィールドと `stop_sequence` フィールドは、[stop_ti
 
 ファイル: **任意**
 
-主キー(`fare_product_id`、 `fare_media_id`)
+主キー(`fare_product_id`、`rider_category_id`、 `fare_media_id`)
 
 乗客が購入可能な運賃の範囲を記述したり、乗り換えコストなど、複数の区間を含む旅程の合計運賃を計算するときに考慮したりするために使用されます。
 
 | フィールド名 | タイプ | 存在 | 説明 |
 |------|------|------|------|
-| `fare_product_id` | ID |**必須**| チケット商品またはチケット商品のセットを識別します。<br><br> [fare_products.txt](#fare_productstxt) 内の複数のレコードが同じ`fare_product_id`を共有するしてもよい。その場合、別のファイルから参照されたときに、そのIDを持つすべてのレコードが取得されます。<br><br>複数のレコードが同じ`fare_product_id` を共有してしてもよいても、異なる`fare_media_id`を持つ場合があります。これは、チケット商品を使用するために利用できるさまざまな方法 (潜在的に異なる価格) を示します。|
+| `fare_product_id` | ID |**必須**| 運賃商品またはチケット商品のセットを識別します。<br><br>同じ`fare_product_id`を共有する複数のレコードは、異なる`fare_media_id`または `rider_category_id` を含む限り許可されます。異なる`fare_media_id`は、運賃商品を使用するためにさまざまな方法が利用可能であることを示し、価格が異なる可能性があります。異なる `rider_category_id` は、運賃商品の対象となるライダー カテゴリが複数あることを示し、価格が異なる可能性があります。|
 | `fare_product_name` |Text|任意| 乗客に表示されるチケット商品の名前。|
+| `rider_category_id` | `rider_categories.rider_category_id` を参照する外部 ID |任意| 運賃商品の対象となるライダー カテゴリを識別します。<br><br> `fare_products.rider_category_id` が空の場合、運賃商品はどの `rider_category_id` でも対象となります。<br><br> `fare_product_id`で指定された単一の運賃商品に複数の乗客カテゴリが該当する場合、これらの乗客カテゴリのうち 1 つだけがデフォルトの乗客カテゴリとして指定されるしなければならない(`is_default_fare_category = 1`)。|
 | `fare_media_id` | `fare_media.fare_media_id`部 ID |任意| 便中にチケット商品を使用するために使用できる運賃メディアを識別します。`fare_media_id` が空の場合、運賃メディアは不明であると見なされます。|
 | `amount` |通貨金額 |**必須**| チケット商品のコスト。乗り継ぎ割引を表す場合は負の値になる場合がしてもよい。無料のチケット商品を表す場合はゼロになる場合がしてもよい。|
 | `currency` | 通貨コード |**必須**| チケット商品のコストの通貨。 |


### PR DESCRIPTION
This PR updates the following files in EN, FR, JA and ES to align with the latest changes in the google/transit repo:

- Schedule Reference
- Schedule Revision History

Changes consist of:

- https://github.com/google/transit/pull/539
- https://github.com/google/transit/pull/511

For the moment I'm not including the latest awesome transit list update (which restructured the content) to prioritize the release of the updated spec documentation. @carlfredl I'll reach out to you next week to sync quickly on this.

As usual, @skalexch do you mind reviewing the English files (just to confirm that changes look good) and the French translation? Thanks!