### PR TITLE
active projects: drop merged GTFS Governance, link to open PRs

### DIFF
--- a/docs/en/community/get-involved.md
+++ b/docs/en/community/get-involved.md
@@ -62,13 +62,13 @@ The community is constantly developing new additions to the specification that c
 
     [:octicons-arrow-right-24: Learn more](../../community/extensions/fares-v2)
 
--   :material-file-document-edit:{ .lg .middle } __GTFS Governance__
+-   :material-source-pull:{ .lg .middle } __Live spec proposals__
 
     ---
 
-    A Working Group has been formed to modify the current GTFS Spec Amendment Process.
+    The current list of changes under discussion lives on GitHub.
 
-    [:octicons-arrow-right-24: Learn more](https://github.com/google/transit/issues/436)
+    [:octicons-arrow-right-24: View pull requests](https://github.com/google/transit/pulls)
 
 </div>
 


### PR DESCRIPTION
GTFS Governance was an active working group when the card was written, but the proposal has since merged so it shouldn't sit under \"active projects\" anymore (per #626). Replaced the slot with a card that points to the [google/transit pulls list](https://github.com/google/transit/pulls), since that's where current proposals actually live — means the page won't drift out of date every time a working group wraps.

closes #626