### PR TITLE
Migrate to mkdocs-materialx theme with new features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ clean:
 
 setup:
 	pip3 install --force-reinstall -r requirements.txt && \
-	pip3 install --upgrade --force-reinstall mkdocs-material
+	pip3 install --upgrade --force-reinstall mkdocs-materialx
 
 serve:
 	make clean

--- a/config/de/mkdocs.yml
+++ b/config/de/mkdocs.yml
@@ -4,6 +4,7 @@ repo_url: https://github.com/google/transit
 repo_name: GTFS-Repository
 docs_dir: ../../docs/de         # Where to find the markdown files
 site_dir: ../../generated/de    # Where to put the HTML files
+edit_uri: edit/main/docs/
 
 validation:
   nav:
@@ -21,12 +22,13 @@ theme:
   logo: assets/images/logo.png
   logo_light_mode: assets/images/logo.png
   favicon: assets/images/favicon.ico
+  topbar_style: glass
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: gtfs
       primary: custom
       accent: custom
-  name: material
+  name: materialx
   font:
     text: Mulish
     code: SF Mono

--- a/config/en/mkdocs.yml
+++ b/config/en/mkdocs.yml
@@ -4,6 +4,7 @@ repo_url: https://github.com/google/transit
 repo_name: GTFS Repository
 docs_dir: ../../docs/en       # Where to find the markdown files
 site_dir: ../../generated/    # Where to put the HTML files
+edit_uri: edit/main/docs/
 
 validation:
   nav:
@@ -21,12 +22,13 @@ theme:
   logo: assets/images/logo.png
   logo_light_mode: assets/images/logo.png
   favicon: assets/images/favicon.ico
+  topbar_style: glass
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: gtfs
       primary: custom
       accent: custom
-  name: material
+  name: materialx
   font:
     text: Mulish
     code: SF Mono
@@ -38,6 +40,7 @@ theme:
     - content.tabs.link
     - search.suggest
     - announce.dismiss
+    - content.action.agents
   icon:
     repo: fontawesome/brands/github
 extra_css:

--- a/config/en/mkdocs.yml
+++ b/config/en/mkdocs.yml
@@ -4,7 +4,7 @@ repo_url: https://github.com/google/transit
 repo_name: GTFS Repository
 docs_dir: ../../docs/en       # Where to find the markdown files
 site_dir: ../../generated/    # Where to put the HTML files
-edit_uri: edit/main/docs/
+edit_uri: edit/main/docs/en/
 
 validation:
   nav:

--- a/config/es/mkdocs.yml
+++ b/config/es/mkdocs.yml
@@ -4,6 +4,7 @@ repo_url: https://github.com/google/transit
 repo_name: Repositorio GTFS
 docs_dir: ../../docs/es       # Where to find the markdown files
 site_dir: ../../generated/es  # Where to put the HTML files
+edit_uri: edit/main/docs/
 
 validation:
   nav:
@@ -21,12 +22,13 @@ theme:
   logo: assets/images/logo.png
   logo_light_mode: assets/images/logo.png
   favicon: assets/images/favicon.ico
+  topbar_style: glass
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: gtfs
       primary: custom
       accent: custom
-  name: material
+  name: materialx
   font:
     text: Mulish
     code: SF Mono
@@ -38,6 +40,7 @@ theme:
     - content.tabs.link
     - search.suggest
     - announce.dismiss
+    - content.action.agents
   icon:
     repo: fontawesome/brands/github
 extra_css:

--- a/config/es/mkdocs.yml
+++ b/config/es/mkdocs.yml
@@ -4,7 +4,7 @@ repo_url: https://github.com/google/transit
 repo_name: Repositorio GTFS
 docs_dir: ../../docs/es       # Where to find the markdown files
 site_dir: ../../generated/es  # Where to put the HTML files
-edit_uri: edit/main/docs/
+edit_uri: edit/main/docs/es/
 
 validation:
   nav:

--- a/config/fr/mkdocs.yml
+++ b/config/fr/mkdocs.yml
@@ -4,7 +4,7 @@ repo_url: https://github.com/google/transit
 repo_name: Répertoire GitHub GTFS
 docs_dir: ../../docs/fr       # Where to find the markdown files
 site_dir: ../../generated/fr  # Where to put the HTML files
-edit_uri: edit/main/docs/
+edit_uri: edit/main/docs/fr/
 
 validation:
   nav:

--- a/config/fr/mkdocs.yml
+++ b/config/fr/mkdocs.yml
@@ -4,6 +4,7 @@ repo_url: https://github.com/google/transit
 repo_name: Répertoire GitHub GTFS
 docs_dir: ../../docs/fr       # Where to find the markdown files
 site_dir: ../../generated/fr  # Where to put the HTML files
+edit_uri: edit/main/docs/
 
 validation:
   nav:
@@ -21,12 +22,13 @@ theme:
   logo: assets/images/logo.png
   logo_light_mode: assets/images/logo.png
   favicon: assets/images/favicon.ico
+  topbar_style: glass
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: gtfs
       primary: custom
       accent: custom
-  name: material
+  name: materialx
   font:
     text: Mulish
     code: SF Mono
@@ -38,6 +40,7 @@ theme:
     - content.tabs.link
     - search.suggest
     - announce.dismiss
+    - content.action.agents
   icon:
     repo: fontawesome/brands/github
 extra_css:

--- a/config/id/mkdocs.yml
+++ b/config/id/mkdocs.yml
@@ -4,6 +4,7 @@ repo_url: https://github.com/google/transit
 repo_name: Gudang GTFS
 docs_dir: ../../docs/id       # Where to find the markdown files
 site_dir: ../../generated/id  # Where to put the HTML files
+edit_uri: edit/main/docs/
 
 validation:
   nav:
@@ -21,12 +22,13 @@ theme:
   logo: assets/images/logo.png
   logo_light_mode: assets/images/logo.png
   favicon: assets/images/favicon.ico
+  topbar_style: glass
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: gtfs
       primary: custom
       accent: custom
-  name: material
+  name: materialx
   font:
     text: Mulish
     code: SF Mono

--- a/config/ja/mkdocs.yml
+++ b/config/ja/mkdocs.yml
@@ -4,6 +4,7 @@ repo_url: https://github.com/google/transit
 repo_name: GTFSリポジトリ
 docs_dir: ../../docs/ja       # Where to find the markdown files
 site_dir: ../../generated/ja  # Where to put the HTML files
+edit_uri: edit/main/docs/
 
 validation:
   nav:
@@ -21,12 +22,13 @@ theme:
   logo: assets/images/logo.png
   logo_light_mode: assets/images/logo.png
   favicon: assets/images/favicon.ico
+  topbar_style: glass
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: gtfs
       primary: custom
       accent: custom
-  name: material
+  name: materialx
   font:
     text: Mulish
     code: SF Mono
@@ -38,6 +40,7 @@ theme:
     - content.tabs.link
     - search.suggest
     - announce.dismiss
+    - content.action.agents
   icon:
     repo: fontawesome/brands/github
 extra_css:

--- a/config/ja/mkdocs.yml
+++ b/config/ja/mkdocs.yml
@@ -4,7 +4,7 @@ repo_url: https://github.com/google/transit
 repo_name: GTFSリポジトリ
 docs_dir: ../../docs/ja       # Where to find the markdown files
 site_dir: ../../generated/ja  # Where to put the HTML files
-edit_uri: edit/main/docs/
+edit_uri: edit/main/docs/ja/
 
 validation:
   nav:

--- a/config/ko/mkdocs.yml
+++ b/config/ko/mkdocs.yml
@@ -4,6 +4,7 @@ repo_url: https://github.com/google/transit
 repo_name: GTFS 저장소
 docs_dir: ../../docs/ko       # Where to find the markdown files
 site_dir: ../../generated/ko  # Where to put the HTML files
+edit_uri: edit/main/docs/
 
 validation:
   nav:
@@ -21,12 +22,13 @@ theme:
   logo: assets/images/logo.png
   logo_light_mode: assets/images/logo.png
   favicon: assets/images/favicon.ico
+  topbar_style: glass
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: gtfs
       primary: custom
       accent: custom
-  name: material
+  name: materialx
   font:
     text: Mulish
     code: SF Mono

--- a/config/pt/mkdocs.yml
+++ b/config/pt/mkdocs.yml
@@ -4,6 +4,7 @@ repo_url: https://github.com/google/transit
 repo_name: Repositório GTFS
 docs_dir: ../../docs/pt       # Where to find the markdown files
 site_dir: ../../generated/pt  # Where to put the HTML files
+edit_uri: edit/main/docs/
 
 validation:
   nav:
@@ -21,12 +22,13 @@ theme:
   logo: assets/images/logo.png
   logo_light_mode: assets/images/logo.png
   favicon: assets/images/favicon.ico
+  topbar_style: glass
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: gtfs
       primary: custom
       accent: custom
-  name: material
+  name: materialx
   font:
     text: Mulish
     code: SF Mono

--- a/config/ru/mkdocs.yml
+++ b/config/ru/mkdocs.yml
@@ -4,6 +4,7 @@ repo_url: https://github.com/google/transit
 repo_name: Репозиторий GTFS
 docs_dir: ../../docs/ru       # Where to find the markdown files
 site_dir: ../../generated/ru  # Where to put the HTML files
+edit_uri: edit/main/docs/
 
 validation:
   nav:
@@ -21,12 +22,13 @@ theme:
   logo: assets/images/logo.png
   logo_light_mode: assets/images/logo.png
   favicon: assets/images/favicon.ico
+  topbar_style: glass
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: gtfs
       primary: custom
       accent: custom
-  name: material
+  name: materialx
   font:
     text: Mulish
     code: SF Mono

--- a/config/zh-TW/mkdocs.yml
+++ b/config/zh-TW/mkdocs.yml
@@ -4,6 +4,7 @@ repo_url: https://github.com/google/transit
 repo_name: GTFS 儲存庫
 docs_dir: ../../docs/zh-TW         # Where to find the markdown files
 site_dir: ../../generated/zh-TW    # Where to put the HTML files
+edit_uri: edit/main/docs/
 
 validation:
   nav:
@@ -21,12 +22,13 @@ theme:
   logo: assets/images/logo.png
   logo_light_mode: assets/images/logo.png
   favicon: assets/images/favicon.ico
+  topbar_style: glass
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: gtfs
       primary: custom
       accent: custom
-  name: material
+  name: materialx
   font:
     text: Mulish
     code: SF Mono

--- a/config/zh/mkdocs.yml
+++ b/config/zh/mkdocs.yml
@@ -4,6 +4,7 @@ repo_url: https://github.com/google/transit
 repo_name: GTFS 存储库
 docs_dir: ../../docs/zh       # Where to find the markdown files
 site_dir: ../../generated/zh  # Where to put the HTML files
+edit_uri: edit/main/docs/
 
 validation:
   nav:
@@ -21,12 +22,13 @@ theme:
   logo: assets/images/logo.png
   logo_light_mode: assets/images/logo.png
   favicon: assets/images/favicon.ico
+  topbar_style: glass
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: gtfs
       primary: custom
       accent: custom
-  name: material
+  name: materialx
   font:
     text: Mulish
     code: SF Mono

--- a/overrides/assets/stylesheets/extra.css
+++ b/overrides/assets/stylesheets/extra.css
@@ -373,7 +373,7 @@ table.example {
 
   .md-nav--primary .md-nav__link--active {
     background-color: var(--md-primary-fg-color) !important;
-    color: #000000 !important;
+    color: var(--md-primary-bg-color) !important;
   }
 
   .md-sidebar.md-sidebar--primary {

--- a/overrides/assets/stylesheets/extra.css
+++ b/overrides/assets/stylesheets/extra.css
@@ -371,6 +371,11 @@ table.example {
     font-weight: bold !important;
   }
 
+  .md-nav--primary .md-nav__link--active {
+    background-color: var(--md-primary-fg-color) !important;
+    color: #000000 !important;
+  }
+
   .md-sidebar.md-sidebar--primary {
     width: 200px;
   }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,16 +5,12 @@ jinja2==3.1.6
 markdown==3.10.2
 markupsafe==3.0.3
 mergedeep==1.3.4
-mkdocs==1.6.1
-mkdocs-material==9.7.6
-mkdocs-material-extensions==1.3.1
+mkdocs-materialx==10.1.5
 mkdocs-redirects==1.2.3
 mkdocs-static-i18n==1.3.1
 mkdocs-embed-external-markdown==3.0.2
 mkdocs-rss-plugin==1.19.0
 packaging==26.2
-pygments==2.20.0
-pymdown-extensions==11.0
 pyparsing==3.3.2
 python-dateutil>=2.9.0.post0
 pyyaml==6.0.3


### PR DESCRIPTION
Upgrade from mkdocs-material to mkdocs-materialx v10.1.5, adding support for:
- Glass-style topbar (`topbar_style: glass`)
- Agent content actions feature
- Edit URI configuration for all locales
- Updated active navigation link styling

Removed redundant dependencies (pygments, pymdown-extensions) that are bundled in the new theme.