### PR TITLE
chore: add robots.txt with AI crawler policy

### DIFF
--- a/docs/en/robots.txt
+++ b/docs/en/robots.txt
@@ -1,0 +1,39 @@
+User-agent: GPTBot
+Disallow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: PerplexityBot
+Disallow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: Applebot-Extended
+Disallow: /
+
+User-agent: *
+Content-Signal: ai-train=no, search=yes, ai-input=no
+Allow: /

--- a/docs/en/robots.txt
+++ b/docs/en/robots.txt
@@ -35,5 +35,5 @@ User-agent: Applebot-Extended
 Allow: /
 
 User-agent: *
-Content-Signal: ai-train=no, search=yes, ai-input=no
+Content-Signal: ai-train=yes, search=yes, ai-input=no
 Allow: /

--- a/docs/en/robots.txt
+++ b/docs/en/robots.txt
@@ -1,14 +1,14 @@
 User-agent: GPTBot
-Disallow: /
+Allow: /
 
 User-agent: OAI-SearchBot
 Allow: /
 
 User-agent: ChatGPT-User
-Disallow: /
+Allow: /
 
 User-agent: Google-Extended
-Disallow: /
+Allow: /
 
 User-agent: Claude-Web
 Allow: /
@@ -20,19 +20,19 @@ User-agent: anthropic-ai
 Allow: /
 
 User-agent: CCBot
-Disallow: /
+Allow: /
 
 User-agent: PerplexityBot
-Disallow: /
+Allow: /
 
 User-agent: Amazonbot
-Disallow: /
+Allow: /
 
 User-agent: Bytespider
-Disallow: /
+Allow: /
 
 User-agent: Applebot-Extended
-Disallow: /
+Allow: /
 
 User-agent: *
 Content-Signal: ai-train=no, search=yes, ai-input=no

--- a/docs/en/robots.txt
+++ b/docs/en/robots.txt
@@ -37,3 +37,5 @@ Allow: /
 User-agent: *
 Content-Signal: ai-train=yes, search=yes, ai-input=no
 Allow: /
+
+Sitemap: https://gtfs.org/sitemap.xml


### PR DESCRIPTION
## Summary
Adds `docs/en/robots.txt`, which the English build copies verbatim to the site root (`generated/robots.txt` → `gtfs.org/robots.txt`).

- Lists the major AI/search crawlers (GPTBot, OAI-SearchBot, ChatGPT-User, Google-Extended, Claude-Web, ClaudeBot, anthropic-ai, CCBot, PerplexityBot, Amazonbot, Bytespider, Applebot-Extended) each with `Allow: /`.
- Catch-all `User-agent: *` with `Content-Signal: ai-train=yes, search=yes, ai-input=no` and `Allow: /`.

## Why here (not per-language)
robots.txt is only honored at the site root. Only the English config builds to `generated/` (the root); every other language builds to `generated/<lang>/`, where a robots.txt would be ignored by crawlers. So a single file under `docs/en/` is the correct and sufficient placement.

## Verification
Built the English site locally and confirmed:
- `generated/robots.txt` exists at the site root and is **byte-for-byte identical** to the source.
- No second or auto-generated robots.txt anywhere in the build (no collision), and no theme wrapping/alteration.

## Note for reviewers
The `Content-Signal` was intentionally set to `ai-train=yes` to stay consistent with the allow-all rules (an earlier draft had `ai-train=no` alongside allow-all, which was contradictory). Confirm the allow-all training posture is the intended policy.