### PR TITLE
gtfs-realtime.proto does not compile in protoc

### DIFF
--- a/docs/en/documentation/realtime/gtfs-realtime.proto
+++ b/docs/en/documentation/realtime/gtfs-realtime.proto
@@ -625,7 +625,6 @@ message Alert {
   // Time when the alert should be shown to the user. If missing, the
   // alert will be shown as long as it appears in the feed.
   // If multiple ranges are given, the alert will be shown during all of them.
-  repeated TimeRange active_period = 1;
   // Should not be used - for backwards-compatibility only.
   repeated TimeRange active_period = 1 [deprecated = true];
 


### PR DESCRIPTION
```
 protoc --dependency_out="C:\Users\Steven\...\deps.d" --csharp_out="C:\Users\Steven\..." --proto_path=. --proto_path="C:\Users\Steven\...protoc\include" "TransitRealtime.FeedMessage.proto"
TransitRealtime.FeedMessage.proto:630:22: "active_period" is already defined in "transit_realtime.Alert".
TransitRealtime.FeedMessage.proto:630:38: Field number 1 has already been used in "transit_realtime.Alert" by field "active_period". Next available field number is 4.
```