### PR TITLE
Remove explicit search.lang from language configs

### DIFF
--- a/config/de/mkdocs.yml
+++ b/config/de/mkdocs.yml
@@ -133,9 +133,7 @@ plugins:
       assets: false
       links_attr_map:
         target: _blank
-  - search:
-      lang: 
-        - de
+  - search
   - redirects:
       redirect_maps:
         'getting-started/what-is-GTFS.md': 'index.md'

--- a/config/ko/mkdocs.yml
+++ b/config/ko/mkdocs.yml
@@ -133,9 +133,7 @@ plugins:
       assets: false
       links_attr_map:
         target: _blank
-  - search:
-      lang: 
-        - ko
+  - search
   - redirects:
       redirect_maps:
         'getting-started/what-is-GTFS.md': 'index.md'

--- a/config/pt/mkdocs.yml
+++ b/config/pt/mkdocs.yml
@@ -135,9 +135,7 @@ plugins:
       assets: false
       links_attr_map:
         target: _blank
-  - search:
-      lang: 
-        - pt
+  - search
   - redirects:
       redirect_maps:
         'getting-started/what-is-GTFS.md': 'index.md'

--- a/config/ru/mkdocs.yml
+++ b/config/ru/mkdocs.yml
@@ -133,9 +133,7 @@ plugins:
       assets: false
       links_attr_map:
         target: _blank
-  - search:
-      lang: 
-        - ru
+  - search
   - redirects:
       redirect_maps:
         'getting-started/what-is-GTFS.md': 'index.md'


### PR DESCRIPTION
Remove the per-language `search` plugin configuration (the `lang:` list) from German, Korean, Portuguese, and Russian mkdocs.yml and replace it with a simple `- search` entry. This aligns these configs with others, avoids redundant per-language settings, and is required by the new MaterialX platform which auto-detects the language.